### PR TITLE
Mostly consistency corrections and syntax errors

### DIFF
--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -1046,96 +1046,105 @@ This project was supported by the by the National Institute of Mental Health of 
 
 '''Unit classes''' <nowiki>[Unit classes and the units for the nodes.]</nowiki>
     * accelerationUnits <nowiki>{defaultUnits=m-per-s^2}</nowiki>
-        ** m-per-s^2 <nowiki>{SIUnit, unitSymbol}</nowiki>
+        ** m-per-s^2 <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
     * angleUnits <nowiki>{defaultUnits=radian}</nowiki>
-        ** radian <nowiki>{SIUnit}</nowiki>
-        ** rad <nowiki>{SIUnit, unitSymbol}</nowiki>
-        ** degree
+        ** radian <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** rad <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+        ** degree <nowiki>{conversionFactor=0.0174533}</nowiki>
     * areaUnits <nowiki>{defaultUnits=m^2}</nowiki>
-        ** m^2 <nowiki>{SIUnit, unitSymbol}</nowiki>
+        ** m^2 <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
     * currencyUnits <nowiki>{defaultUnits=$}[Units indicating the worth of something.]</nowiki>
-        ** dollar
-        ** $ <nowiki>{unitPrefix, unitSymbol}</nowiki>
+        ** dollar <nowiki>{conversionFactor=1.0}</nowiki>
+        ** $ <nowiki>{unitPrefix, unitSymbol, conversionFactor=1.0}</nowiki>
+        ** euro
         ** point
-    * frequencyUnits <nowiki>{defaultUnits=Hz}</nowiki>
-        ** hertz  <nowiki>{SIUnit}</nowiki>
-        ** Hz <nowiki>{SIUnit, unitSymbol}</nowiki>
-    * amplitudeUnits <nowiki>{defaultUnits=microvolts}</nowiki>
-        ** microvolts
+    * electricPotentialUnits <nowiki>{defaultUnits=uv}</nowiki>
+        ** v <nowiki>{SIUnit, unitSymbol, conversionFactor=0.000001}</nowiki>
+        ** Volt <nowiki>{SIUnit, conversionFactor=0.000001}</nowiki>
+        * frequencyUnits <nowiki>{defaultUnits=Hz}</nowiki>
+        ** hertz  <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** Hz <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
     * intensityUnits <nowiki>{defaultUnits=dB}</nowiki>
-        ** dB <nowiki>{unitSymbol}[Intensity expressed as ratio to a threshold. Often used for sound intensity.]</nowiki>
+        ** dB <nowiki>{unitSymbol, conversionFactor=1.0}[Intensity expressed as ratio to a threshold. May be used for sound intensity.]</nowiki>
         ** candela <nowiki>{SIUnit}[Units used to express light intensity.]</nowiki>
         ** cd <nowiki>{SIUnit, unitSymbol}[Units used to express light intensity.]</nowiki>
     * jerkUnits <nowiki>{defaultUnits=m-per-s^3}</nowiki>
-        ** m-per-s^3 <nowiki>{unitSymbol}</nowiki>
+        ** m-per-s^3 <nowiki>{unitSymbol, conversionFactor=1.0}</nowiki>
+    * magneticFieldUnits <nowiki>{defaultUnits=fT}[Units used to magnetic field intensity.]</nowiki>
+        ** tesla <nowiki>{SIUnit, conversionFactor=10^-15}</nowiki>
+        ** T <nowiki>{SIUnit, unitSymbol, conversionFactor=10^-15}</nowiki>
     * memorySizeUnits <nowiki>{defaultUnits=B}</nowiki>
-        ** byte <nowiki>{SIUnit}</nowiki>
-        ** B <nowiki>{SIUnit, unitSymbol}</nowiki>
+        ** byte <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** B <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
     * physicalLengthUnits <nowiki>{defaultUnits=m}</nowiki>
-        ** foot
-        ** inch
-        ** metre <nowiki>{SIUnit}</nowiki>
-        ** m <nowiki>{SIUnit, unitSymbol}</nowiki>
-        ** mile
+        ** foot <nowiki>{conversionFactor=0.3048}</nowiki>
+        ** inch <nowiki>{conversionFactor=0.0254}</nowiki>
+        ** metre <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** m <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+        ** mile <nowiki>{conversionFactor=1609.34}</nowiki>
     * speedUnits <nowiki>{defaultUnits=m-per-s}</nowiki>
-        ** m-per-s <nowiki>{SIUnit, unitSymbol}</nowiki>
-        ** mph <nowiki>{unitSymbol}</nowiki>
-        ** kph <nowiki>{unitSymbol}</nowiki>
+        ** m-per-s <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+        ** mph <nowiki>{unitSymbol, conversionFactor=0.44704}</nowiki>
+        ** kph <nowiki>{unitSymbol, conversionFactor=0.277778}</nowiki>
+    * temperatureUnits <nowiki>{defaultUnits=degree Celsius}</nowiki>
+        ** degree Celsius <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** oC <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
     * timeUnits <nowiki>{defaultUnits=s}</nowiki>
-        ** second <nowiki>{SIUnit}</nowiki>
-        ** s <nowiki>{SIUnit, unitSymbol}</nowiki>
-        ** day
-        ** minute
-        ** hour <nowiki>[Should be in 24-hour format.]</nowiki>
+        ** second <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** s <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+        ** day <nowiki>{conversionFactor=86400}</nowiki>
+        ** minute <nowiki>{conversionFactor=60}</nowiki>
+        ** hour <nowiki>{conversionFactor=3600}[Should be in 24-hour format.]</nowiki>
     * volumeUnits <nowiki>{defaultUnits=m^3}</nowiki>
-        ** m^3 <nowiki>{SIUnit, unitSymbol}</nowiki>
+        ** m^3 <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
     * weightUnits <nowiki>{defaultUnits=g}</nowiki>
-        ** g <nowiki>{SIUnit, unitSymbol}</nowiki>
-        ** gram <nowiki>{SIUnit}</nowiki>
-        ** pound
-        ** lb
+        ** g <nowiki>{SIUnit, unitSymbol, conversionFactor=1.0}</nowiki>
+        ** gram <nowiki>{SIUnit, conversionFactor=1.0}</nowiki>
+        ** pound <nowiki>{conversionFactor=453.592}</nowiki>
+        ** lb <nowiki>{conversionFactor=453.592}</nowiki>
+
 
 '''Unit modifiers''' <nowiki>[Unit multiples and submultiples.]</nowiki>
-    * deca <nowiki>{SIUnitModifier} [SI unit multiple representing 10^1]</nowiki>
-    * da <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^1]</nowiki>
-    * hecto <nowiki>{SIUnitModifier} [SI unit multiple representing 10^2]</nowiki>
-    * h <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^2]</nowiki>
-    * kilo <nowiki>{SIUnitModifier} [SI unit multiple representing 10^3]</nowiki>
-    * k <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^3]</nowiki>
-    * mega <nowiki>{SIUnitModifier} [SI unit multiple representing 10^6]</nowiki>
-    * M <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^6]</nowiki>
-    * giga <nowiki>{SIUnitModifier} [SI unit multiple representing 10^9]</nowiki>
-    * G <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^9]</nowiki>
-    * tera <nowiki>{SIUnitModifier} [SI unit multiple representing 10^12]</nowiki>
-    * T <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^12]</nowiki>
-    * peta <nowiki>{SIUnitModifier} [SI unit multiple representing 10^15]</nowiki>
-    * P <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^15]</nowiki>
-    * exa <nowiki>{SIUnitModifier} [SI unit multiple representing 10^18]</nowiki>
-    * E <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^18]</nowiki>
-    * zetta <nowiki>{SIUnitModifier} [SI unit multiple representing 10^21]</nowiki>
-    * Z <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^21]</nowiki>
-    * yotta <nowiki>{SIUnitModifier} [SI unit multiple representing 10^24]</nowiki>
-    * Y <nowiki>{SIUnitSymbolModifier} [SI unit multiple representing 10^24]</nowiki>
-    * deci <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-1]</nowiki>
-    * d <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-1]</nowiki>
-    * centi <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-2]</nowiki>
-    * c <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-2]</nowiki>
-    * milli <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-3]</nowiki>
-    * m <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-3]</nowiki>
-    * micro <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-6]</nowiki>
-    * u <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-6]</nowiki>
-    * nano <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-9]</nowiki>
-    * n <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-9]</nowiki>
-    * pico <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-12]</nowiki>
-    * p <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-12]</nowiki>
-    * femto <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-15]</nowiki>
-    * f <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-15]</nowiki>
-    * atto <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-18]</nowiki>
-    * a <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-18]</nowiki>
-    * zepto <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-21]</nowiki>
-    * z <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-21]</nowiki>
-    * yocto <nowiki>{SIUnitModifier} [SI unit submultiple representing 10^-24]</nowiki>
-    * y <nowiki>{SIUnitSymbolModifier} [SI unit submultiple representing 10^-24]</nowiki>
+    * deca <nowiki>{SIUnitModifier, conversionFactor=10.0} [SI unit multiple representing 10^1]</nowiki>
+    * da <nowiki>{SIUnitSymbolModifier, conversionFactor=10.0} [SI unit multiple representing 10^1]</nowiki>
+    * hecto <nowiki>{SIUnitModifier, conversionFactor=100.0} [SI unit multiple representing 10^2]</nowiki>
+    * h <nowiki>{SIUnitSymbolModifier, conversionFactor=100.0} [SI unit multiple representing 10^2]</nowiki>
+    * kilo <nowiki>{SIUnitModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3]</nowiki>
+    * k <nowiki>{SIUnitSymbolModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3]</nowiki>
+    * mega <nowiki>{SIUnitModifier, conversionFactor=10^6} [SI unit multiple representing 10^6]</nowiki>
+    * M <nowiki>{SIUnitSymbolModifier, conversionFactor=10^6} [SI unit multiple representing 10^6]</nowiki>
+    * giga <nowiki>{SIUnitModifier, conversionFactor=10^9} [SI unit multiple representing 10^9]</nowiki>
+    * G <nowiki>{SIUnitSymbolModifier, conversionFactor=10^9} [SI unit multiple representing 10^9]</nowiki>
+    * tera <nowiki>{SIUnitModifier, conversionFactor=10^12} [SI unit multiple representing 10^12]</nowiki>
+    * T <nowiki>{SIUnitSymbolModifier, conversionFactor=10^12} [SI unit multiple representing 10^12]</nowiki>
+    * peta <nowiki>{SIUnitModifier, conversionFactor=10^15} [SI unit multiple representing 10^15]</nowiki>
+    * P <nowiki>{SIUnitSymbolModifier, conversionFactor=10^15} [SI unit multiple representing 10^15]</nowiki>
+    * exa <nowiki>{SIUnitModifier, conversionFactor=10^18} [SI unit multiple representing 10^18]</nowiki>
+    * E <nowiki>{SIUnitSymbolModifier, conversionFactor=10^18} [SI unit multiple representing 10^18]</nowiki>
+    * zetta <nowiki>{SIUnitModifier, conversionFactor=10^21} [SI unit multiple representing 10^21]</nowiki>
+    * Z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^21} [SI unit multiple representing 10^21]</nowiki>
+    * yotta <nowiki>{SIUnitModifier, conversionFactor=10^24} [SI unit multiple representing 10^24]</nowiki>
+    * Y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^24} [SI unit multiple representing 10^24]</nowiki>
+    * deci <nowiki>{SIUnitModifier, conversionFactor=0.1}[SI unit submultiple representing 10^-1]</nowiki>
+    * d <nowiki>{SIUnitSymbolModifier, conversionFactor=0.1} [SI unit submultiple representing 10^-1]</nowiki>
+    * centi <nowiki>{SIUnitModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2]</nowiki>
+    * c <nowiki>{SIUnitSymbolModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2]</nowiki>
+    * milli <nowiki>{SIUnitModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3]</nowiki>
+    * m <nowiki>{SIUnitSymbolModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3]</nowiki>
+    * micro <nowiki>{SIUnitModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6]</nowiki>
+    * u <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6]</nowiki>
+    * nano <nowiki>{SIUnitModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9]</nowiki>
+    * n <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9]</nowiki>
+    * pico <nowiki>{SIUnitModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12]</nowiki>
+    * p <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12]</nowiki>
+    * femto <nowiki>{SIUnitModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15]</nowiki>
+    * f <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15]</nowiki>
+    * atto <nowiki>{SIUnitModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18]</nowiki>
+    * a <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18]</nowiki>
+    * zepto <nowiki>{SIUnitModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21]</nowiki>
+    * z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21]</nowiki>
+    * yocto <nowiki>{SIUnitModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24]</nowiki>
+    * y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24]</nowiki>
 
 '''Value classes''' <nowiki>[Specification of the rules for the values provided by users.]</nowiki>
     * dateTimeClass <nowiki>{allowedCharacter=digits,allowedCharacter=T,allowedCharacter=-,allowedCharacter=:}[Date-times should conform to ISO8601 date-time format YYYY-MM-DDThh:mm:ss. Any variation on the full form is allowed.]</nowiki>
@@ -1146,6 +1155,7 @@ This project was supported by the by the National Institute of Mental Health of 
 
 '''Schema attributes''' <nowiki>[Allowed node, unit class or unit modifier attributes.]</nowiki>
     * allowedCharacter <nowiki>{valueClassProperty}[A schema attribute of value classes specifying a special character that is allowed in expressing the value of a placeholder. Normally the allowed characters are listed individually. However, the word letters designates the upper and lower case alphabetic characters and the word digits designates the digits 0-9. The word blank designates the blank character.]</nowiki>
+    * conversionFactor <nowiki>{unitProperty, unitModifierProperty}[The multiplicative factor to multiply these units to convert to default units.]</nowiki>
     * defaultUnits <nowiki>{unitClassProperty}[A schema attribute of unit classes specifying the default units to use if the placeholder has a unit class but the substituted value has no units.]</nowiki>
     * extensionAllowed <nowiki>{boolProperty}[A schema attribute indicating that users can add unlimited levels of child nodes under this tag. This tag is propagated to child nodes with the exception of the hashtag placeholders.]</nowiki>
     * recommended  <nowiki>{boolProperty}[A schema attribute indicating that the event-level HED string should include this tag.]</nowiki>
@@ -1158,7 +1168,7 @@ This project was supported by the by the National Institute of Mental Health of 
     * suggestedTag <nowiki>[A schema attribute that indicates another tag  that is often associated with this tag. This attribute is used by tagging tools to provide tagging suggestions.]</nowiki>
     * tagGroup <nowiki>{boolProperty}[A schema attribute indicating the tag can only appear inside a tag group.] </nowiki>
     * takesValue <nowiki>{boolProperty}[A schema attribute indicating the tag is a hashtag placeholder that is expected to be replaced with a user-defined value.] </nowiki>
-    * topLevelTagGroup <nowiki>{boolProperty}[A schema attribute indicating that this tag (or its descendants) can only appear in a top-level tag group.] </nowiki>
+    * topLevelTagGroup <nowiki>{boolProperty}[A schema attribute indicating that this tag (or its descendants) can only appear in a top-level tag group. A tag group can have at most one tag with this attribute.] </nowiki>
     * unique <nowiki>{boolProperty}[A schema attribute indicating that only one of this tag or its descendants can be used  in the event-level HED string.]</nowiki>
     * unitClass <nowiki>[A schema attribute specifying which unit class this value tag belongs to.]</nowiki>
     * unitPrefix <nowiki>{boolProperty, unitProperty}[A schema attribute applied specifically to unit elements to designate that the unit indicator is a prefix (e.g., dollar sign in the currency units).]</nowiki>

--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -871,18 +871,18 @@ This project was supported by the by the National Institute of Mental Health of 
                     ***** Semiology-motor-eye-blinking
                     ***** Semiology-motor-other-elementary-motor
                         ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-                **** Semiology-motor-automatisms
-                    ***** Semiology-motor-automatisms-mimetic <nowiki>[Facial expression suggesting an emotional state, often fear.]</nowiki>
-                    ***** Semiology-motor-automatisms-oroalimentary <nowiki>[Lip smacking, lip pursing, chewing, licking, tooth grinding, or swallowing.]</nowiki>
-                    ***** Semiology-motor-automatisms-dacrystic <nowiki>[Bursts of crying.]</nowiki>
-                    ***** Semiology-motor-automatisms-dyspraxic <nowiki>[Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation.]</nowiki>
-                    ***** Semiology-motor-automatisms-manual <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
-                    ***** Semiology-motor-automatisms-gestural <nowiki>[Semipurposive, asynchronous hand movements. Often unilateral.]</nowiki>
-                    ***** Semiology-motor-automatisms-pedal <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
-                    ***** Semiology-motor-automatisms-hypermotor <nowiki>[1. Involves predominantly proximal limb or axial muscles producing irregular sequential ballistic movements, such as pedaling, pelvic thrusting, thrashing, rocking movements. 2. Increase in rate of ongoing movements or inappropriately rapid performance of a movement.]</nowiki>
-                    ***** Semiology-motor-automatisms-hypokinetic <nowiki>[A decrease in amplitude and/or rate or arrest of ongoing motor activity.]</nowiki>
-                    ***** Semiology-motor-automatisms-gelastic <nowiki>[Bursts of laughter or giggling, usually without an appropriate affective tone.]</nowiki>
-                    ***** Semiology-motor-other-automatisms
+                **** Semiology-motor-automatism
+                    ***** Semiology-motor-automatism-mimetic <nowiki>[Facial expression suggesting an emotional state, often fear.]</nowiki>
+                    ***** Semiology-motor-automatism-oroalimentary <nowiki>[Lip smacking, lip pursing, chewing, licking, tooth grinding, or swallowing.]</nowiki>
+                    ***** Semiology-motor-automatism-dacrystic <nowiki>[Bursts of crying.]</nowiki>
+                    ***** Semiology-motor-automatism-dyspraxic <nowiki>[Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation.]</nowiki>
+                    ***** Semiology-motor-automatism-manual <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
+                    ***** Semiology-motor-automatism-gestural <nowiki>[Semipurposive, asynchronous hand movements. Often unilateral.]</nowiki>
+                    ***** Semiology-motor-automatism-pedal <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
+                    ***** Semiology-motor-automatism-hypermotor <nowiki>[1. Involves predominantly proximal limb or axial muscles producing irregular sequential ballistic movements, such as pedaling, pelvic thrusting, thrashing, rocking movements. 2. Increase in rate of ongoing movements or inappropriately rapid performance of a movement.]</nowiki>
+                    ***** Semiology-motor-automatism-hypokinetic <nowiki>[A decrease in amplitude and/or rate or arrest of ongoing motor activity.]</nowiki>
+                    ***** Semiology-motor-automatism-gelastic <nowiki>[Bursts of laughter or giggling, usually without an appropriate affective tone.]</nowiki>
+                    ***** Semiology-motor-other-automatism
                         ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Semiology-motor-behavioral-arrest <nowiki>[Interruption of ongoing motor activity or of ongoing behaviors with fixed gaze, without movement of the head or trunk (oro-alimentary and hand automatisms may continue).]</nowiki>
             *** Semiology-non-motor-manifestation
@@ -1101,46 +1101,46 @@ This project was supported by the by the National Institute of Mental Health of 
 
 
 '''Unit modifiers''' <nowiki>[Unit multiples and submultiples.]</nowiki>
-    * deca <nowiki>{SIUnitModifier, conversionFactor=10.0} [SI unit multiple representing 10^1]</nowiki>
-    * da <nowiki>{SIUnitSymbolModifier, conversionFactor=10.0} [SI unit multiple representing 10^1]</nowiki>
-    * hecto <nowiki>{SIUnitModifier, conversionFactor=100.0} [SI unit multiple representing 10^2]</nowiki>
-    * h <nowiki>{SIUnitSymbolModifier, conversionFactor=100.0} [SI unit multiple representing 10^2]</nowiki>
-    * kilo <nowiki>{SIUnitModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3]</nowiki>
-    * k <nowiki>{SIUnitSymbolModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3]</nowiki>
-    * mega <nowiki>{SIUnitModifier, conversionFactor=10^6} [SI unit multiple representing 10^6]</nowiki>
-    * M <nowiki>{SIUnitSymbolModifier, conversionFactor=10^6} [SI unit multiple representing 10^6]</nowiki>
-    * giga <nowiki>{SIUnitModifier, conversionFactor=10^9} [SI unit multiple representing 10^9]</nowiki>
-    * G <nowiki>{SIUnitSymbolModifier, conversionFactor=10^9} [SI unit multiple representing 10^9]</nowiki>
-    * tera <nowiki>{SIUnitModifier, conversionFactor=10^12} [SI unit multiple representing 10^12]</nowiki>
-    * T <nowiki>{SIUnitSymbolModifier, conversionFactor=10^12} [SI unit multiple representing 10^12]</nowiki>
-    * peta <nowiki>{SIUnitModifier, conversionFactor=10^15} [SI unit multiple representing 10^15]</nowiki>
-    * P <nowiki>{SIUnitSymbolModifier, conversionFactor=10^15} [SI unit multiple representing 10^15]</nowiki>
-    * exa <nowiki>{SIUnitModifier, conversionFactor=10^18} [SI unit multiple representing 10^18]</nowiki>
-    * E <nowiki>{SIUnitSymbolModifier, conversionFactor=10^18} [SI unit multiple representing 10^18]</nowiki>
-    * zetta <nowiki>{SIUnitModifier, conversionFactor=10^21} [SI unit multiple representing 10^21]</nowiki>
-    * Z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^21} [SI unit multiple representing 10^21]</nowiki>
-    * yotta <nowiki>{SIUnitModifier, conversionFactor=10^24} [SI unit multiple representing 10^24]</nowiki>
-    * Y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^24} [SI unit multiple representing 10^24]</nowiki>
-    * deci <nowiki>{SIUnitModifier, conversionFactor=0.1}[SI unit submultiple representing 10^-1]</nowiki>
-    * d <nowiki>{SIUnitSymbolModifier, conversionFactor=0.1} [SI unit submultiple representing 10^-1]</nowiki>
-    * centi <nowiki>{SIUnitModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2]</nowiki>
-    * c <nowiki>{SIUnitSymbolModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2]</nowiki>
-    * milli <nowiki>{SIUnitModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3]</nowiki>
-    * m <nowiki>{SIUnitSymbolModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3]</nowiki>
-    * micro <nowiki>{SIUnitModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6]</nowiki>
-    * u <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6]</nowiki>
-    * nano <nowiki>{SIUnitModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9]</nowiki>
-    * n <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9]</nowiki>
-    * pico <nowiki>{SIUnitModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12]</nowiki>
-    * p <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12]</nowiki>
-    * femto <nowiki>{SIUnitModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15]</nowiki>
-    * f <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15]</nowiki>
-    * atto <nowiki>{SIUnitModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18]</nowiki>
-    * a <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18]</nowiki>
-    * zepto <nowiki>{SIUnitModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21]</nowiki>
-    * z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21]</nowiki>
-    * yocto <nowiki>{SIUnitModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24]</nowiki>
-    * y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24]</nowiki>
+    * deca <nowiki>{SIUnitModifier, conversionFactor=10.0} [SI unit multiple representing 10^1.]</nowiki>
+    * da <nowiki>{SIUnitSymbolModifier, conversionFactor=10.0} [SI unit multiple representing 10^1.]</nowiki>
+    * hecto <nowiki>{SIUnitModifier, conversionFactor=100.0} [SI unit multiple representing 10^2.]</nowiki>
+    * h <nowiki>{SIUnitSymbolModifier, conversionFactor=100.0} [SI unit multiple representing 10^2.]</nowiki>
+    * kilo <nowiki>{SIUnitModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3.]</nowiki>
+    * k <nowiki>{SIUnitSymbolModifier, conversionFactor=1000.0} [SI unit multiple representing 10^3.]</nowiki>
+    * mega <nowiki>{SIUnitModifier, conversionFactor=10^6} [SI unit multiple representing 10^6.]</nowiki>
+    * M <nowiki>{SIUnitSymbolModifier, conversionFactor=10^6} [SI unit multiple representing 10^6.]</nowiki>
+    * giga <nowiki>{SIUnitModifier, conversionFactor=10^9} [SI unit multiple representing 10^9.]</nowiki>
+    * G <nowiki>{SIUnitSymbolModifier, conversionFactor=10^9} [SI unit multiple representing 10^9.]</nowiki>
+    * tera <nowiki>{SIUnitModifier, conversionFactor=10^12} [SI unit multiple representing 10^12.]</nowiki>
+    * T <nowiki>{SIUnitSymbolModifier, conversionFactor=10^12} [SI unit multiple representing 10^12.]</nowiki>
+    * peta <nowiki>{SIUnitModifier, conversionFactor=10^15} [SI unit multiple representing 10^15.]</nowiki>
+    * P <nowiki>{SIUnitSymbolModifier, conversionFactor=10^15} [SI unit multiple representing 10^15.]</nowiki>
+    * exa <nowiki>{SIUnitModifier, conversionFactor=10^18} [SI unit multiple representing 10^18.]</nowiki>
+    * E <nowiki>{SIUnitSymbolModifier, conversionFactor=10^18} [SI unit multiple representing 10^18.]</nowiki>
+    * zetta <nowiki>{SIUnitModifier, conversionFactor=10^21} [SI unit multiple representing 10^21.]</nowiki>
+    * Z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^21} [SI unit multiple representing 10^21.]</nowiki>
+    * yotta <nowiki>{SIUnitModifier, conversionFactor=10^24} [SI unit multiple representing 10^24.]</nowiki>
+    * Y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^24} [SI unit multiple representing 10^24.]</nowiki>
+    * deci <nowiki>{SIUnitModifier, conversionFactor=0.1}[SI unit submultiple representing 10^-1.]</nowiki>
+    * d <nowiki>{SIUnitSymbolModifier, conversionFactor=0.1} [SI unit submultiple representing 10^-1.]</nowiki>
+    * centi <nowiki>{SIUnitModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2.]</nowiki>
+    * c <nowiki>{SIUnitSymbolModifier, conversionFactor=0.01} [SI unit submultiple representing 10^-2.]</nowiki>
+    * milli <nowiki>{SIUnitModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3.]</nowiki>
+    * m <nowiki>{SIUnitSymbolModifier, conversionFactor=0.001} [SI unit submultiple representing 10^-3.]</nowiki>
+    * micro <nowiki>{SIUnitModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6.]</nowiki>
+    * u <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-6} [SI unit submultiple representing 10^-6.]</nowiki>
+    * nano <nowiki>{SIUnitModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9.]</nowiki>
+    * n <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-9} [SI unit submultiple representing 10^-9.]</nowiki>
+    * pico <nowiki>{SIUnitModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12.]</nowiki>
+    * p <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-12} [SI unit submultiple representing 10^-12.]</nowiki>
+    * femto <nowiki>{SIUnitModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15.]</nowiki>
+    * f <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-15} [SI unit submultiple representing 10^-15.]</nowiki>
+    * atto <nowiki>{SIUnitModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18.]</nowiki>
+    * a <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-18} [SI unit submultiple representing 10^-18.]</nowiki>
+    * zepto <nowiki>{SIUnitModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21.]</nowiki>
+    * z <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-21} [SI unit submultiple representing 10^-21.]</nowiki>
+    * yocto <nowiki>{SIUnitModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24.]</nowiki>
+    * y <nowiki>{SIUnitSymbolModifier, conversionFactor=10^-24} [SI unit submultiple representing 10^-24.]</nowiki>
 
 '''Value classes''' <nowiki>[Specification of the rules for the values provided by users.]</nowiki>
     * dateTimeClass <nowiki>{allowedCharacter=digits,allowedCharacter=T,allowedCharacter=-,allowedCharacter=:}[Date-times should conform to ISO8601 date-time format YYYY-MM-DDThh:mm:ss. Any variation on the full form is allowed.]</nowiki>

--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -110,11 +110,11 @@ This project was supported by the by the National Institute of Mental Health of 
     * Epileptiform-interictal-activity
     * Abnormal-interictal-rhythmic-activity
     * Interictal-special-patterns
-        ** Interictal-periodic-discharge <nowiki>[Periodic discharge not further specified (PD).]</nowiki>
-        ** Generalized-periodic-discharge <nowiki>[GPD.]</nowiki>
-        ** Lateralized-periodic-discharge <nowiki>[LPD.]</nowiki>
-        ** Bilateral-independent-periodic-discharge <nowiki>[BIPD.]</nowiki>
-        ** Multifocal-periodic-discharge <nowiki>[MfPD.]</nowiki>
+        ** Interictal-periodic-discharges <nowiki>[Periodic discharge not further specified (PDs).]</nowiki>
+        ** Generalized-periodic-discharges <nowiki>[GPDs.]</nowiki>
+        ** Lateralized-periodic-discharges <nowiki>[LPDs.]</nowiki>
+        ** Bilateral-independent-periodic-discharges <nowiki>[BIPDs.]</nowiki>
+        ** Multifocal-periodic-discharges <nowiki>[MfPDs.]</nowiki>
         ** Interictal-extreme-delta-brush
         ** Interictal-burst-suppression <nowiki>[]</nowiki>
         ** Interictal-burst-attenuation <nowiki>[]</nowiki>
@@ -131,7 +131,7 @@ This project was supported by the by the National Institute of Mental Health of 
         ** Generalized-onset-epileptic-seizure
         ** Unknown-onset-epileptic-seizure
         ** Unclassified-epileptic-seizure
-    * Subtle-seizure <nowiki>[Seizure type frequent in neonates, sometimes referred to as motor automatism; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges, and are clearly epileptic, ictal EEG often does not show typical epileptic activity.] </nowiki>
+    * Subtle-seizure <nowiki>[Seizure type frequent in neonates, sometimes referred to as motor automatisms; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges, and are clearly epileptic, ictal EEG often does not show typical epileptic activity.] </nowiki>
     * Electrographic-seizure <nowiki>[Referred usually to non convulsive status. Ictal EEG: rhythmic discharge or spike and wave pattern with definite evolution in frequency, location, or morphology lasting at least 10 s; evolution in amplitude alone did not qualify.] </nowiki>
     * Seizure-PNES <nowiki>[Psychogenic non-epileptic seizure.] </nowiki>
     * Sleep-related-episode
@@ -871,18 +871,18 @@ This project was supported by the by the National Institute of Mental Health of 
                     ***** Semiology-motor-eye-blinking
                     ***** Semiology-motor-other-elementary-motor
                         ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-                **** Semiology-motor-automatism
-                    ***** Semiology-motor-automatism-mimetic <nowiki>[Facial expression suggesting an emotional state, often fear.]</nowiki>
-                    ***** Semiology-motor-automatism-oroalimentary <nowiki>[Lip smacking, lip pursing, chewing, licking, tooth grinding, or swallowing.]</nowiki>
-                    ***** Semiology-motor-automatism-dacrystic <nowiki>[Bursts of crying.]</nowiki>
-                    ***** Semiology-motor-automatism-dyspraxic <nowiki>[Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation.]</nowiki>
-                    ***** Semiology-motor-automatism-manual <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
-                    ***** Semiology-motor-automatism-gestural <nowiki>[Semipurposive, asynchronous hand movements. Often unilateral.]</nowiki>
-                    ***** Semiology-motor-automatism-pedal <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
-                    ***** Semiology-motor-automatism-hypermotor <nowiki>[1. Involves predominantly proximal limb or axial muscles producing irregular sequential ballistic movements, such as pedaling, pelvic thrusting, thrashing, rocking movements. 2. Increase in rate of ongoing movements or inappropriately rapid performance of a movement.]</nowiki>
-                    ***** Semiology-motor-automatism-hypokinetic <nowiki>[A decrease in amplitude and/or rate or arrest of ongoing motor activity.]</nowiki>
-                    ***** Semiology-motor-automatism-gelastic <nowiki>[Bursts of laughter or giggling, usually without an appropriate affective tone.]</nowiki>
-                    ***** Semiology-motor-other-automatism
+                **** Semiology-motor-automatisms
+                    ***** Semiology-motor-automatisms-mimetic <nowiki>[Facial expression suggesting an emotional state, often fear.]</nowiki>
+                    ***** Semiology-motor-automatisms-oroalimentary <nowiki>[Lip smacking, lip pursing, chewing, licking, tooth grinding, or swallowing.]</nowiki>
+                    ***** Semiology-motor-automatisms-dacrystic <nowiki>[Bursts of crying.]</nowiki>
+                    ***** Semiology-motor-automatisms-dyspraxic <nowiki>[Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation.]</nowiki>
+                    ***** Semiology-motor-automatisms-manual <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
+                    ***** Semiology-motor-automatisms-gestural <nowiki>[Semipurposive, asynchronous hand movements. Often unilateral.]</nowiki>
+                    ***** Semiology-motor-automatisms-pedal <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
+                    ***** Semiology-motor-automatisms-hypermotor <nowiki>[1. Involves predominantly proximal limb or axial muscles producing irregular sequential ballistic movements, such as pedaling, pelvic thrusting, thrashing, rocking movements. 2. Increase in rate of ongoing movements or inappropriately rapid performance of a movement.]</nowiki>
+                    ***** Semiology-motor-automatisms-hypokinetic <nowiki>[A decrease in amplitude and/or rate or arrest of ongoing motor activity.]</nowiki>
+                    ***** Semiology-motor-automatisms-gelastic <nowiki>[Bursts of laughter or giggling, usually without an appropriate affective tone.]</nowiki>
+                    ***** Semiology-motor-other-automatisms
                         ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Semiology-motor-behavioral-arrest <nowiki>[Interruption of ongoing motor activity or of ongoing behaviors with fixed gaze, without movement of the head or trunk (oro-alimentary and hand automatisms may continue).]</nowiki>
             *** Semiology-non-motor-manifestation

--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -78,7 +78,7 @@ This project was supported by the by the National Institute of Mental Health of 
 
 '''Sleep-drowsiness''' <nowiki>[The features of the ongoing activity during sleep are scored here. If abnormal graphoelements appear, disappear or change their morphology during sleep, that is not scored here but at the entry corresponding to that graphooelement (as a modulator).]</nowiki>
 
-    * Sleep-architecture <nowiki> {suggestedTag=Finding-attribute/Significance}[For longer recordings. Only to be scored if whole-night sleep is part of the recording. It is a global descriptor of the structure and pattern of sleep: estimation of the amount of time spent in REM and NREM sleep, sleep duration, NREM-REM cycle.]</nowiki>
+    * Sleep-architecture <nowiki> {suggestedTag=Finding-significance}[For longer recordings. Only to be scored if whole-night sleep is part of the recording. It is a global descriptor of the structure and pattern of sleep: estimation of the amount of time spent in REM and NREM sleep, sleep duration, NREM-REM cycle.]</nowiki>
         ** Normal-sleep-architecture
         ** Abnormal-sleep-architecture
         ** Sleep-architecture-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
@@ -86,9 +86,9 @@ This project was supported by the by the National Institute of Mental Health of 
 
     * Sleep-stage-reached <nowiki>[For normal sleep patterns the sleep stages reached during the recording can be specified]</nowiki>
         ** Sleep-stage-N1 <nowiki>[Sleep stage 1.]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Sleep-stage-N2 <nowiki>[Sleep stage 2.]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Sleep-stage-N3 <nowiki>[Sleep stage 3.]</nowiki>
             *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Sleep-stage-REM <nowiki>[Rapid eye movement.]</nowiki>
@@ -96,13 +96,13 @@ This project was supported by the by the National Institute of Mental Health of 
         ** Sleep-stage-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
             *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-    * Sleep-spindles <nowiki> {suggestedTag=Finding-attribute/Significance} [Burst at 11-15 Hz but mostly at 12-14 Hz generally diffuse but of higher voltage over the central regions of the head, occurring during sleep. Amplitude varies but is mostly below 50 microV in the adult.]</nowiki>
-    * Sleep-vertex-wave <nowiki> {suggestedTag=Finding-attribute/Significance} [Sharp potential, maximal at the vertex, negative relative to other areas, apparently occurring spontaneously during sleep or in response to a sensory stimulus during sleep or wakefulness. May be single or repetitive. Amplitude varies but rarely exceeds 250 microV. Abbreviation: V wave. Synonym: vertex sharp wave.]</nowiki>
-    * Sleep-K-complex <nowiki> {suggestedTag=Finding-attribute/Significance}[A burst of somewhat variable appearance, consisting most commonly of a high voltage negative slow wave followed by a smaller positive slow wave frequently associated with a sleep spindle. Duration greater than 0.5 s. Amplitude is generally maximal in the frontal vertex. K complexes occur during nonREM sleep, apparently spontaneously, or in response to sudden sensory / auditory stimuli, and are not specific for any individual sensory modality.]</nowiki>
-    * Sleep-saw-tooth-waves <nowiki> {suggestedTag=Finding-attribute/Significance} </nowiki>
-    * Sleep-POSTS <nowiki> {suggestedTag=Finding-attribute/Significance} [Positive occipital sharp transients of sleep. Sharp transient maximal over the occipital regions, positive relative to other areas, apparently occurring spontaneously during sleep. May be single or repetitive. Amplitude varies but is generally bellow 50 microV.]</nowiki>
-    * Hypnagogic-hypersynchrony {suggestedTag=Finding-attribute/Significance} <nowiki>[Bursts of bilateral, synchronous delta or theta activity of large amplitude, occasionally with superimposed faster components, occurring during falling asleep or during awakening, in children.]</nowiki>
-    * Non-reactive-sleep <nowiki> {suggestedTag=Finding-attribute/Significance} [EEG activity consisting of normal sleep graphoelemts, but which cannot be interrupted by external stimuli/ the patient cannot be waken.]</nowiki>
+    * Sleep-spindles <nowiki> {suggestedTag=Finding-significance} [Burst at 11-15 Hz but mostly at 12-14 Hz generally diffuse but of higher voltage over the central regions of the head, occurring during sleep. Amplitude varies but is mostly below 50 microV in the adult.]</nowiki>
+    * Sleep-vertex-wave <nowiki> {suggestedTag=Finding-significance} [Sharp potential, maximal at the vertex, negative relative to other areas, apparently occurring spontaneously during sleep or in response to a sensory stimulus during sleep or wakefulness. May be single or repetitive. Amplitude varies but rarely exceeds 250 microV. Abbreviation: V wave. Synonym: vertex sharp wave.]</nowiki>
+    * Sleep-K-complex <nowiki> {suggestedTag=Finding-significance}[A burst of somewhat variable appearance, consisting most commonly of a high voltage negative slow wave followed by a smaller positive slow wave frequently associated with a sleep spindle. Duration greater than 0.5 s. Amplitude is generally maximal in the frontal vertex. K complexes occur during nonREM sleep, apparently spontaneously, or in response to sudden sensory / auditory stimuli, and are not specific for any individual sensory modality.]</nowiki>
+    * Sleep-saw-tooth-waves <nowiki> {suggestedTag=Finding-significance} </nowiki>
+    * Sleep-POSTS <nowiki> {suggestedTag=Finding-significance} [Positive occipital sharp transients of sleep. Sharp transient maximal over the occipital regions, positive relative to other areas, apparently occurring spontaneously during sleep. May be single or repetitive. Amplitude varies but is generally bellow 50 microV.]</nowiki>
+    * Hypnagogic-hypersynchrony {suggestedTag=Finding-significance} <nowiki>[Bursts of bilateral, synchronous delta or theta activity of large amplitude, occasionally with superimposed faster components, occurring during falling asleep or during awakening, in children.]</nowiki>
+    * Non-reactive-sleep <nowiki> {suggestedTag=Finding-significance} [EEG activity consisting of normal sleep graphoelemts, but which cannot be interrupted by external stimuli/ the patient cannot be waken.]</nowiki>
 
 
 '''Interictal-finding''' <nowiki>[EEG pattern / transient that is distinguished form the background activity, considered abnormal, but is not recorded during ictal period (seizure) or postictal period; the presence of an interictal finding does not necessarily imply that the patient has epilepsy.]</nowiki>
@@ -193,38 +193,38 @@ This project was supported by the by the National Institute of Mental Health of 
 '''EEG-artifact''' <nowiki>[When relevant for the clinical interpretation, artifacts can be scored by specifying the type and the location.]</nowiki>
 
     * Biological-artifact
-        ** Eye-blink-artifact <nowiki> {suggestedTag=Finding-attribute/Significance} [Fp1/Fp2 become electropositive with eye closure because the cornea is positively charged causing a negative deflection in Fp1/Fp2. If the eye blink is unilateral, consider prosthetic eye. If it is in F8 rather than Fp2 then the electrodes are plugged in wrong.]</nowiki>
-        ** Eye-movement-horizontal-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[There is an upward deflection in the Fp2-F8 derivation, when the eyes move to the right side. In this case F8 becomes more positive and therefore. When the eyes move to the left, F7 becomes more positive and there is an upward deflection in the Fp1-F7 derivation.] </nowiki>
-        ** Eye-movement-vertical-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[The EEG shows positive potentials (50-100 micro V) with bi-frontal distribution, maximum at Fp1 and Fp2, when the eyeball rotated upward. The downward rotation of the eyeball was associated with the negative deflection. The time course of the deflections was similar to the time course of the eyeball movement.]</nowiki>
-        ** Slow-eye-movement-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Slow, rolling eye-movements, seen during drowsiness.]</nowiki>
-        ** Nystagmus-artifact {suggestedTag=Finding-attribute/Significance}
-        ** Chewing-artifact {suggestedTag=Finding-attribute/Significance}
-        ** Sucking-artifact {suggestedTag=Finding-attribute/Significance}
-        ** Glossokinetic-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[The tongue functions as a dipole, with the tip negative with respect to the base. The artifact produced by the tongue has a broad potential field that drops from frontal to occipital areas, although it is less steep than that produced by eye movement artifacts. The amplitude of the potentials is greater inferiorly than in parasagittal regions; the frequency is variable but usually in the delta range. Chewing and sucking can produce similar artifacts.] </nowiki>
-        ** Rocking-patting-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Quasi-rhythmical artifacts in recordings from infants caused by rocking/ patting.]</nowiki>
-        ** Movement-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Large amplitude artifact, with irregular morphology (usually resembling a slow-wave or a wave with complex morphology) seen in one or several channels, due to movement. If the causing movement is repetitive, the artifact might resemble a rhythmic EEG activity.] </nowiki>
-        ** Respiration-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Respiration can produce 2 kinds of artifacts. One type is in the form of slow and rhythmic activity, synchronous with the body movements of respiration and mechanically affecting the impedance of (usually) one electrode. The other type can be slow or sharp waves that occur synchronously with inhalation or exhalation and involve those electrodes on which the patient is lying.] </nowiki>
-        ** Pulse-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Occurs when an EEG electrode is placed over a pulsating vessel. The pulsation can cause slow waves that may simulate EEG activity. A direct relationship exists between ECG and the pulse waves (200-300 millisecond delay after ECG equals QRS complex).]</nowiki>
-        ** ECG-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Far-field potential generated in the heart. The voltage and apparent surface of the artifact vary from derivation to derivation and, consequently, from montage to montage. The artifact is observed best in referential montages using earlobe electrodes A1 and A2. ECG artifact is recognized easily by its rhythmicity/regularity and coincidence with the ECG tracing.] </nowiki>
-        ** Sweat-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Is a low amplitude undulating waveform that is usually greater than 2 seconds and may appear to be an unstable baseline.] </nowiki>
-        ** EMG-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Myogenic potentials are the most common artifacts. Frontalis and temporalis muscles (ex..: clenching of jaw muscles) are common causes. Generally, the potentials generated in the muscles are of shorter duration than those generated in the brain. The frequency components are usually beyond 30-50 Hz, and the bursts are arrhythmic.] </nowiki>
+        ** Eye-blink-artifact <nowiki> {suggestedTag=Finding-significance} [Fp1/Fp2 become electropositive with eye closure because the cornea is positively charged causing a negative deflection in Fp1/Fp2. If the eye blink is unilateral, consider prosthetic eye. If it is in F8 rather than Fp2 then the electrodes are plugged in wrong.]</nowiki>
+        ** Eye-movement-horizontal-artifact {suggestedTag=Finding-significance} <nowiki>[There is an upward deflection in the Fp2-F8 derivation, when the eyes move to the right side. In this case F8 becomes more positive and therefore. When the eyes move to the left, F7 becomes more positive and there is an upward deflection in the Fp1-F7 derivation.] </nowiki>
+        ** Eye-movement-vertical-artifact {suggestedTag=Finding-significance} <nowiki>[The EEG shows positive potentials (50-100 micro V) with bi-frontal distribution, maximum at Fp1 and Fp2, when the eyeball rotated upward. The downward rotation of the eyeball was associated with the negative deflection. The time course of the deflections was similar to the time course of the eyeball movement.]</nowiki>
+        ** Slow-eye-movement-artifact {suggestedTag=Finding-significance} <nowiki>[Slow, rolling eye-movements, seen during drowsiness.]</nowiki>
+        ** Nystagmus-artifact {suggestedTag=Finding-significance}
+        ** Chewing-artifact {suggestedTag=Finding-significance}
+        ** Sucking-artifact {suggestedTag=Finding-significance}
+        ** Glossokinetic-artifact {suggestedTag=Finding-significance} <nowiki>[The tongue functions as a dipole, with the tip negative with respect to the base. The artifact produced by the tongue has a broad potential field that drops from frontal to occipital areas, although it is less steep than that produced by eye movement artifacts. The amplitude of the potentials is greater inferiorly than in parasagittal regions; the frequency is variable but usually in the delta range. Chewing and sucking can produce similar artifacts.] </nowiki>
+        ** Rocking-patting-artifact {suggestedTag=Finding-significance} <nowiki>[Quasi-rhythmical artifacts in recordings from infants caused by rocking/ patting.]</nowiki>
+        ** Movement-artifact {suggestedTag=Finding-significance} <nowiki>[Large amplitude artifact, with irregular morphology (usually resembling a slow-wave or a wave with complex morphology) seen in one or several channels, due to movement. If the causing movement is repetitive, the artifact might resemble a rhythmic EEG activity.] </nowiki>
+        ** Respiration-artifact {suggestedTag=Finding-significance} <nowiki>[Respiration can produce 2 kinds of artifacts. One type is in the form of slow and rhythmic activity, synchronous with the body movements of respiration and mechanically affecting the impedance of (usually) one electrode. The other type can be slow or sharp waves that occur synchronously with inhalation or exhalation and involve those electrodes on which the patient is lying.] </nowiki>
+        ** Pulse-artifact {suggestedTag=Finding-significance} <nowiki>[Occurs when an EEG electrode is placed over a pulsating vessel. The pulsation can cause slow waves that may simulate EEG activity. A direct relationship exists between ECG and the pulse waves (200-300 millisecond delay after ECG equals QRS complex).]</nowiki>
+        ** ECG-artifact {suggestedTag=Finding-significance} <nowiki>[Far-field potential generated in the heart. The voltage and apparent surface of the artifact vary from derivation to derivation and, consequently, from montage to montage. The artifact is observed best in referential montages using earlobe electrodes A1 and A2. ECG artifact is recognized easily by its rhythmicity/regularity and coincidence with the ECG tracing.] </nowiki>
+        ** Sweat-artifact {suggestedTag=Finding-significance} <nowiki>[Is a low amplitude undulating waveform that is usually greater than 2 seconds and may appear to be an unstable baseline.] </nowiki>
+        ** EMG-artifact {suggestedTag=Finding-significance} <nowiki>[Myogenic potentials are the most common artifacts. Frontalis and temporalis muscles (ex..: clenching of jaw muscles) are common causes. Generally, the potentials generated in the muscles are of shorter duration than those generated in the brain. The frequency components are usually beyond 30-50 Hz, and the bursts are arrhythmic.] </nowiki>
 
     * Non-biological-artifact
-        ** Power-supply-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[50-60 Hz artifact. Monomorphic waveform due to 50 or 60 Hz A/C power supply.] </nowiki>
-        ** Induction-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Artifacts (usually of high frequency) induced by nearby equipment (like in the intensive care unit).] </nowiki>
-        ** Dialysis-artifact {suggestedTag=Finding-attribute/Significance}
-        ** Artificial-ventilation-artifact {suggestedTag=Finding-attribute/Significance}
-        ** Electrode-pops-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Are brief discharges with a very steep upslope and shallow fall that occur in all leads which include that electrode.] </nowiki>
-        ** Salt-bridge-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Typically occurs in 1 channel which may appear isoelectric. Only seen in bipolar montage.] </nowiki>
+        ** Power-supply-artifact {suggestedTag=Finding-significance} <nowiki>[50-60 Hz artifact. Monomorphic waveform due to 50 or 60 Hz A/C power supply.] </nowiki>
+        ** Induction-artifact {suggestedTag=Finding-significance} <nowiki>[Artifacts (usually of high frequency) induced by nearby equipment (like in the intensive care unit).] </nowiki>
+        ** Dialysis-artifact {suggestedTag=Finding-significance}
+        ** Artificial-ventilation-artifact {suggestedTag=Finding-significance}
+        ** Electrode-pops-artifact {suggestedTag=Finding-significance} <nowiki>[Are brief discharges with a very steep upslope and shallow fall that occur in all leads which include that electrode.] </nowiki>
+        ** Salt-bridge-artifact {suggestedTag=Finding-significance} <nowiki>[Typically occurs in 1 channel which may appear isoelectric. Only seen in bipolar montage.] </nowiki>
 
-    * Other-EEG-artifact <nowiki> {suggestedTag=Finding-attribute/Significance} </nowiki>
+    * Other-EEG-artifact <nowiki> {suggestedTag=Finding-significance} </nowiki>
         ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 '''Polygraphic-channel-finding''' <nowiki>[Changes observed in polygraphic channels can be scored: EOG, Respiration, ECG, EMG, other polygraphic channel (+ free text), and their significance logged (normal, abnormal, no definite abnormality).]</nowiki>
 
-    * EOG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [Electrooculography]</nowiki>
+    * EOG-channel-finding <nowiki> {suggestedTag=Finding-significance} [Electrooculography]</nowiki>
         ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-    * Respiration-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance}</nowiki>
+    * Respiration-channel-finding <nowiki> {suggestedTag=Finding-significance}</nowiki>
         ** Respiration-oxygen-saturation
             *** <nowiki># {takesValue, valueClass=numericClass}</nowiki>
         ** Respiration-feature
@@ -241,8 +241,8 @@ This project was supported by the by the National Institute of Mental Health of 
                 **** Tachypnea-respiration-frequency <nowiki>[cycles/min (numbers) typed in.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-respiration-feature
-                **** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
-    * ECG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [Electrocardiography.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+    * ECG-channel-finding <nowiki> {suggestedTag=Finding-significance} [Electrocardiography.]</nowiki>
         ** ECG-QT-period
             *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** ECG-feature
@@ -270,7 +270,7 @@ This project was supported by the by the National Institute of Mental Health of 
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-ECG-feature
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-    * EMG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [electromyography]</nowiki>
+    * EMG-channel-finding <nowiki> {suggestedTag=Finding-significance} [electromyography]</nowiki>
         ** EMG-muscle-side
             *** EMG-left-muscle
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
@@ -605,7 +605,7 @@ This project was supported by the by the National Institute of Mental Health of 
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Provocative-factor <nowiki>[Provocative factors are defined as transient and sporadic endogenous or exogenous elements capable of evoking/triggering seizures immediately following the exposure to it.]</nowiki>
             *** Hyperventilation-provoked
-                **** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Reflex-provoked
                  **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Medication-effect-clinical <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications clinical effect. Used with base schema Increasing/Decreasing.]</nowiki>
@@ -969,7 +969,7 @@ This project was supported by the by the National Institute of Mental Health of 
                 **** Episode-consciousness-mildly-affected
                     ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Episode-consciousness-not-affected
-                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Episode-consciousness-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
@@ -984,17 +984,14 @@ This project was supported by the by the National Institute of Mental Health of 
             *** Clinical-EEG-temporal-relationship
                 **** Clinical-start-followed-EEG <nowiki>[Clinical start, followed by EEG start by X seconds.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=timeUnits}</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
                 **** EEG-start-followed-clinical <nowiki>[EEG start, followed by clinical start by X seconds.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=timeUnits}</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
                 **** Simultaneous-start-clinical-EEG
                 **** Clinical-EEG-temporal-relationship-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Episode-event-count <nowiki>[Number of stereotypical episodes during the recording.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass} </nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
                 **** Episode-event-count-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 

--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -989,6 +989,8 @@ This project was supported by the by the National Institute of Mental Health of 
                 **** Simultaneous-start-clinical-EEG
                 **** Clinical-EEG-temporal-relationship-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Clinical-EEG-temporal-relationship-notes <nowiki>[Clinical notes to annotate the clinical-EEG temporal relationship.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}</nowiki>
 
             *** Episode-event-count <nowiki>[Number of stereotypical episodes during the recording.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass} </nowiki>

--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -21,52 +21,52 @@ This project was supported by the by the National Institute of Mental Health of 
     * Hyperventilation
         ** Quality-of-hyperventilation
             *** Hyperventilation-refused-procedure
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Hyperventilation-poor-effort
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Hyperventilation-good-effort
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Hyperventilation-excellent-effort
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Sleep-deprivation
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Sleep-following-sleep-deprivation
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Natural-sleep
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Induced-sleep
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Drowsiness
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Awakening
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Medication-administered-during-recording
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Medication-withdrawal-or-reduction-during-recording
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Manual-eye-closure
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Manual-eye-opening
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Auditory-stimulation
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Nociceptive-stimulation
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Physical-effort
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-    * Cognitive-tasks
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-    * Other-modulators-and-procedures
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+    * Cognitive-task
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+    * Other-modulator-or-procedure
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 
 '''Background-activity''' <nowiki>[An EEG activity representing the setting in which a given normal or abnormal pattern appears and from which such pattern is distinguished.]</nowiki>
 
     * Posterior-dominant-rhythm <nowiki>[Rhythmic activity occurring during wakefulness over the posterior regions of the head, generally with maximum amplitudes over the occipital areas. Amplitude varies. Best seen with eyes closed and during physical relaxation and relative mental inactivity. Blocked or attenuated by attention, especially visual, and mental effort. In adults this is the alpha rhythm, and the frequency is 8 to 13 Hz. However the frequency can be higher or lower than this range (often a supra or sub harmonic of alpha frequency) and is called alpha variant rhythm (fast and slow alpha variant rhythm). In children, the normal range of the frequency of the posterior dominant rhythm is age-dependant.]</nowiki>
     * Mu-rhythm <nowiki>[EEG rhythm at 7-11 Hz composed of arch-shaped waves occurring over the central or centro-parietal regions of the scalp during wakefulness. Amplitudes varies but is mostly below 50 microV. Blocked or attenuated most clearly by contralateral movement, thought of movement, readiness to move or tactile stimulation.]</nowiki>
-    * Other-organized-rhythms <nowiki>[EEG activity that consisting of waves of approximately constant period, which is considered as part of the background (ongoing) activity, but does not fulfil the criteria of the posterior dominant rhythm.]</nowiki>
+    * Other-organized-rhythm <nowiki>[EEG activity that consisting of waves of approximately constant period, which is considered as part of the background (ongoing) activity, but does not fulfill the criteria of the posterior dominant rhythm.]</nowiki>
 
-    * Special-background-activity-features <nowiki>[Special Features. Special features contains scoring options for the background activity of critically ill patients.]</nowiki>
+    * Special-background-activity-feature <nowiki>[Special Features. Special features contains scoring options for the background activity of critically ill patients.]</nowiki>
         ** Continuous-background-activity
         ** Nearly-continuous-background-activity
         ** Discontinuous-background-activity
@@ -81,20 +81,20 @@ This project was supported by the by the National Institute of Mental Health of 
     * Sleep-architecture <nowiki> {suggestedTag=Finding-attribute/Significance}[For longer recordings. Only to be scored if whole-night sleep is part of the recording. It is a global descriptor of the structure and pattern of sleep: estimation of the amount of time spent in REM and NREM sleep, sleep duration, NREM-REM cycle.]</nowiki>
         ** Normal-sleep-architecture
         ** Abnormal-sleep-architecture
-        ** Sleep-architecture-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Sleep-architecture-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Sleep-stage-reached <nowiki>[For normal sleep patterns the sleep stages reached during the recording can be specified]</nowiki>
-        ** Sleep-stage-N1 <nowiki>[Sleep stage 1]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sleep-stage-N2 <nowiki>[Sleep stage 2]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sleep-stage-N3 <nowiki>[Sleep stage 3]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sleep-stage-REM <nowiki>[Rapid eye movement]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sleep-stage-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Sleep-stage-N1 <nowiki>[Sleep stage 1.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+        ** Sleep-stage-N2 <nowiki>[Sleep stage 2.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+        ** Sleep-stage-N3 <nowiki>[Sleep stage 3.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Sleep-stage-REM <nowiki>[Rapid eye movement.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Sleep-stage-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Sleep-spindles <nowiki> {suggestedTag=Finding-attribute/Significance} [Burst at 11-15 Hz but mostly at 12-14 Hz generally diffuse but of higher voltage over the central regions of the head, occurring during sleep. Amplitude varies but is mostly below 50 microV in the adult.]</nowiki>
     * Sleep-vertex-wave <nowiki> {suggestedTag=Finding-attribute/Significance} [Sharp potential, maximal at the vertex, negative relative to other areas, apparently occurring spontaneously during sleep or in response to a sensory stimulus during sleep or wakefulness. May be single or repetitive. Amplitude varies but rarely exceeds 250 microV. Abbreviation: V wave. Synonym: vertex sharp wave.]</nowiki>
@@ -105,22 +105,22 @@ This project was supported by the by the National Institute of Mental Health of 
     * Non-reactive-sleep <nowiki> {suggestedTag=Finding-attribute/Significance} [EEG activity consisting of normal sleep graphoelemts, but which cannot be interrupted by external stimuli/ the patient cannot be waken.]</nowiki>
 
 
-'''Interictal-findings''' <nowiki>[EEG patterns / transients that are distinguished form the background activity, considered abnormal, but are not recorded during ictal period (seizure) or postictal period; the presence of interictal findings does not necessarily imply that the patient has epilepsy.]</nowiki>
+'''Interictal-finding''' <nowiki>[EEG pattern / transient that is distinguished form the background activity, considered abnormal, but is not recorded during ictal period (seizure) or postictal period; the presence of an interictal finding does not necessarily imply that the patient has epilepsy.]</nowiki>
 
     * Epileptiform-interictal-activity
     * Abnormal-interictal-rhythmic-activity
     * Interictal-special-patterns
-        ** Interictal-periodic-discharges <nowiki>[Periodic discharges not further specified (PDs).]</nowiki>
-        ** Generalized-periodic-discharges <nowiki>[GPDs]</nowiki>
-        ** Lateralized-periodic-discharges <nowiki>[LPDs]</nowiki>
-        ** Bilateral-independent-periodic-discharges <nowiki>[BIPDs]</nowiki>
-        ** Multifocal-periodic-discharges <nowiki>[MfPDs]</nowiki>
+        ** Interictal-periodic-discharge <nowiki>[Periodic discharge not further specified (PD).]</nowiki>
+        ** Generalized-periodic-discharge <nowiki>[GPD.]</nowiki>
+        ** Lateralized-periodic-discharge <nowiki>[LPD.]</nowiki>
+        ** Bilateral-independent-periodic-discharge <nowiki>[BIPD.]</nowiki>
+        ** Multifocal-periodic-discharge <nowiki>[MfPD.]</nowiki>
         ** Interictal-extreme-delta-brush
         ** Interictal-burst-suppression <nowiki>[]</nowiki>
         ** Interictal-burst-attenuation <nowiki>[]</nowiki>
 
 
-'''Episode''' <nowiki>[Clinical episodes or electrographic seizures.] </nowiki>
+'''Episode''' <nowiki>[Clinical episode or electrographic seizure.] </nowiki>
 
     * Epileptic-seizure
         ** Focal-onset-epileptic-seizure
@@ -131,32 +131,31 @@ This project was supported by the by the National Institute of Mental Health of 
         ** Generalized-onset-epileptic-seizure
         ** Unknown-onset-epileptic-seizure
         ** Unclassified-epileptic-seizure
-    * Subtle-seizure <nowiki>[Seizure type frequent in neonates, sometimes referred to as motor automatism; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges , and are clearly epileptic, ictal EEG often does not show typical epileptic activity] </nowiki>
-    * Electrographic-seizure <nowiki>[Referred usually to non convulsive status. Ictal EEG: rhythmic discharge or spike and wave pattern with definite evolution in frequency, location, or morphology lasting at least 10 s; evolution in amplitude alone did not qualify] </nowiki>
-    * Seizure-PNES <nowiki>[Psychogenic non-epileptic seizure] </nowiki>
-    * Sleep-related-episodes
-        ** Sleep-related-arousal <nowiki>[Normal] </nowiki>
+    * Subtle-seizure <nowiki>[Seizure type frequent in neonates, sometimes referred to as motor automatism; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges, and are clearly epileptic, ictal EEG often does not show typical epileptic activity.] </nowiki>
+    * Electrographic-seizure <nowiki>[Referred usually to non convulsive status. Ictal EEG: rhythmic discharge or spike and wave pattern with definite evolution in frequency, location, or morphology lasting at least 10 s; evolution in amplitude alone did not qualify.] </nowiki>
+    * Seizure-PNES <nowiki>[Psychogenic non-epileptic seizure.] </nowiki>
+    * Sleep-related-episode
+        ** Sleep-related-arousal <nowiki>[Normal.] </nowiki>
         ** Benign-sleep-myoclonus <nowiki>[A distinctive disorder of sleep characterized by a) neonatal onset, b) rhythmic myoclonic jerks only during sleep and c) abrupt and consistent cessation with arousal, d) absence of concomitant electrographic changes suggestive of seizures, and e) good outcome.] </nowiki>
-        ** Confusional-awakening <nowiki>[Episodes of non epileptic nature included in NREM parasomnias, characterized by sudden arousal and complex behavior but without full alertness, usually lasting a few minutes and occurring almost in all children at least occasionally. Amnesia of the episode is the rule.] </nowiki>
-        ** Sleep-periodic-limb-movement <nowiki>[PLMS. Periodic limb movement in sleep. Episodes characterized by brief (0.5- to 5.0-second) lower-extremity movements during sleep, which typically occur at 20- to 40-second intervals, most commonly during the first 3 hours of sleep. The affected individual is usually not aware of the movements or of the transient partial arousals.] </nowiki>
+        ** Confusional-awakening <nowiki>[Episode of non epileptic nature included in NREM parasomnias, characterized by sudden arousal and complex behavior but without full alertness, usually lasting a few minutes and occurring almost in all children at least occasionally. Amnesia of the episode is the rule.] </nowiki>
+        ** Sleep-periodic-limb-movement <nowiki>[PLMS. Periodic limb movement in sleep. Episodes are characterized by brief (0.5- to 5.0-second) lower-extremity movements during sleep, which typically occur at 20- to 40-second intervals, most commonly during the first 3 hours of sleep. The affected individual is usually not aware of the movements or of the transient partial arousals.] </nowiki>
         ** REM-sleep-behavioral-disorder <nowiki>[REM sleep behavioral disorder. Episodes characterized by: a) presence of REM sleep without atonia (RSWA) on polysomnography (PSG); b) presence of at least 1 of the following conditions - (1) Sleep-related behaviors, by history, that have been injurious, potentially injurious, or disruptive (example: dream enactment behavior); (2) abnormal REM sleep behavior documented during PSG monitoring; (3) absence of epileptiform activity on electroencephalogram (EEG) during REM sleep (unless RBD can be clearly distinguished from any concurrent REM sleep-related seizure disorder); (4) sleep disorder not better explained by another sleep disorder, a medical or neurologic disorder, a mental disorder, medication use, or a substance use disorder.] </nowiki>
         ** Sleep-walking <nowiki>[Episodes characterized by ambulation during sleep; the patient is difficult to arouse during an episode, and is usually amnesic following the episode. Episodes usually occur in the first third of the night during slow wave sleep. Polysomnographic recordings demonstrate 2 abnormalities during the first sleep cycle: frequent, brief, non-behavioral EEG-defined arousals prior to the somnambulistic episode and abnormally low gamma (0.75-2.0 Hz) EEG power on spectral analysis, correlating with high-voltage (hyper-synchronic gamma) waves lasting 10 to 15 s occurring just prior to the movement. This is followed by stage I NREM sleep, and there is no evidence of complete awakening.] </nowiki>
-    * Pediatric-episodes
+    * Pediatric-episode
         ** Hyperekplexia <nowiki>[Disorder characterized by exaggerated startle response and hypertonicity that may occur during the first year of life and in severe cases during the neonatal period. Children usually present with marked irritability and recurrent startles in response to handling and sounds. Severely affected infants can have severe jerks and stiffening, sometimes with breath-holding spells.] </nowiki>
         ** Jactatio-capitis-nocturna <nowiki>[Relatively common in normal children at the time of going to bed, especially during the first year of life, the rhythmic head movements persist during sleep. Usually, these phenomena disappear before 3 years of age.] </nowiki>
-        ** Pavor-nocturnus <nowiki>[Nocturnal episodes characterized by age of onset of less than five years (mean age 18 months, with peak prevalence at five to seven years), appearance of signs of panic two hours after falling asleep with crying, screams, a fearful expression, inability to recognize other people including parents (for a duration of 5-15 minutes), amnesia upon awakening. Pavor nocturnus occurs in patients almost every night for months or years (but the frequency is highly variable and may be as low as once a month) and is likely to disappear spontaneously at the age of six to eight years. ] </nowiki>
-        ** Pediatric-stereotypical-behavior-episode <nowiki>[Repetitive motor behavior in children, typically rhythmic and persistent; usually not paroxysmal and rarely suggest epilepsy. They include headbanging, head-rolling, jactatio capitis nocturna, body rocking, buccal or lingual movements, hand flapping and related mannerisms, repetitive hand-waving (to self-induce photosensitive seizures). ] </nowiki>
-
-    * Paroxysmal-motor-event <nowiki>[Paroxysmal phenomena during neonatal or childhood periods characterized by recurrent motor or behavioral signs or symptoms that must be distinguishes from epileptic disorders. ] </nowiki>
-    * Syncope <nowiki>[Episode with loss of consciousness and muscle tone that is abrupt in onset, of short duration and followed by rapid recovery; it occurs in response to transient impairment of cerebral perfusion. Typical prodromal symptoms often herald onset of syncope and postictal symptoms are minimal. Syncopal convulsions resulting from cerebral anoxia are common but are not a form of epilepsy, nor are there any accompanying EEG ictal discharges. ] </nowiki>
+        ** Pavor-nocturnus <nowiki>[A nocturnal episode characterized by age of onset of less than five years (mean age 18 months, with peak prevalence at five to seven years), appearance of signs of panic two hours after falling asleep with crying, screams, a fearful expression, inability to recognize other people including parents (for a duration of 5-15 minutes), amnesia upon awakening. Pavor nocturnus occurs in patients almost every night for months or years (but the frequency is highly variable and may be as low as once a month) and is likely to disappear spontaneously at the age of six to eight years.] </nowiki>
+        ** Pediatric-stereotypical-behavior-episode <nowiki>[Repetitive motor behavior in children, typically rhythmic and persistent; usually not paroxysmal and rarely suggest epilepsy. They include headbanging, head-rolling, jactatio capitis nocturna, body rocking, buccal or lingual movements, hand flapping and related mannerisms, repetitive hand-waving (to self-induce photosensitive seizures).] </nowiki>
+    * Paroxysmal-motor-event <nowiki>[Paroxysmal phenomena during neonatal or childhood periods characterized by recurrent motor or behavioral signs or symptoms that must be distinguishes from epileptic disorders.] </nowiki>
+    * Syncope <nowiki>[Episode with loss of consciousness and muscle tone that is abrupt in onset, of short duration and followed by rapid recovery; it occurs in response to transient impairment of cerebral perfusion. Typical prodromal symptoms often herald onset of syncope and postictal symptoms are minimal. Syncopal convulsions resulting from cerebral anoxia are common but are not a form of epilepsy, nor are there any accompanying EEG ictal discharges.] </nowiki>
     * Cataplexy <nowiki>[A sudden decrement in muscle tone and loss of deep tendon reflexes, leading to muscle weakness, paralysis, or postural collapse. Cataplexy usually is precipitated by an outburst of emotional expression-notably laughter, anger, or startle. It is one of the tetrad of symptoms of narcolepsy. During cataplexy, respiration and voluntary eye movements are not compromised. Consciousness is preserved.] </nowiki>
     * Other-episode
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 
 '''Physiologic-pattern''' <nowiki>[EEG graphoelements or rhythms that are considered normal. They only should be scored if the physician considers that they have a specific clinical significance for the recording.]</nowiki>
 
-    * Rhythmic-activity-pattern <nowiki>[Not further specified] </nowiki>
+    * Rhythmic-activity-pattern <nowiki>[Not further specified.] </nowiki>
     * Slow-alpha-variant-rhythm <nowiki>[Characteristic rhythms mostly at 4-5 Hz, recorded most prominently over the posterior regions of the head. Generally alternate, or are intermixed, with alpha rhythm to which they often are harmonically related. Amplitude varies but is frequently close to 50 micro V. Blocked or attenuated by attention, especially visual, and mental effort. Comment: slow alpha variant rhythms should be distinguished from posterior slow waves characteristic of children and adolescents and occasionally seen in young adults.] </nowiki>
     * Fast-alpha-variant-rhythm <nowiki>[Characteristic rhythm at 14-20 Hz, detected most prominently over the posterior regions of the head. May alternate or be intermixed with alpha rhythm. Blocked or attenuated by attention, especially visual, and mental effort.] </nowiki>
     * Ciganek-rhythm <nowiki>[Midline theta rhythm (Ciganek rhythm) may be observed during wakefulness or drowsiness. The frequency is 4-7 Hz, and the location is midline (ie, vertex). The morphology is rhythmic, smooth, sinusoidal, arciform, spiky, or mu-like.]</nowiki>
@@ -172,13 +171,13 @@ This project was supported by the by the National Institute of Mental Health of 
     * POSTS-pattern <nowiki>[Positive occipital sharp transient of sleep. Sharp transient maximal over the occipital regions, positive relative to other areas, apparently occurring spontaneously during sleep. May be single or repetitive. Amplitude varies but is generally bellow 50 micro V.] </nowiki>
     * Frontal-arousal-rhythm <nowiki>[Prolonged (up to 20s) rhythmical sharp or spiky activity over the frontal areas (maximum over the frontal midline) seen at arousal from sleep in children with minimal cerebral dysfunction.] </nowiki>
     * Other-physiologic-pattern
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 '''Uncertain-significant-pattern''' <nowiki>[EEG graphoelements or rhythms that resemble abnormal patterns but that are not necessarily associated with a pathology, and the physician does not consider them abnormal in the context of the scored recording (like normal variants and patterns).]</nowiki>
 
     * Sharp-transient-pattern
-    * Wicket-spikes <nowiki>[Spike-like monophasic negative single waves or trains of waves occurring over the temporal regions during drowsiness that have an arcuate or mu-like appearance. These are mainly seen in older individuals and represent a benign variant that is of little clinical significance. ] </nowiki>
-    * Small-sharp-spikes <nowiki>[Benign epileptiform Transients of Sleep (BETS). Small sharp spikes (SSS) of very short duration and low amplitude, often followed by a small theta wave, occurring in the temporal regions during drowsiness and light sleep. They occur on one or both sides (often asynchronously). The main negative and positive components are of about equally spiky character. Rarely seen in children, they are seen most often in adults and the elderly. Two thirds of the patients have a history of epileptic seizures. ] </nowiki>
+    * Wicket-spikes <nowiki>[Spike-like monophasic negative single waves or trains of waves occurring over the temporal regions during drowsiness that have an arcuate or mu-like appearance. These are mainly seen in older individuals and represent a benign variant that is of little clinical significance.] </nowiki>
+    * Small-sharp-spikes <nowiki>[Benign epileptiform Transients of Sleep (BETS). Small sharp spikes (SSS) of very short duration and low amplitude, often followed by a small theta wave, occurring in the temporal regions during drowsiness and light sleep. They occur on one or both sides (often asynchronously). The main negative and positive components are of about equally spiky character. Rarely seen in children, they are seen most often in adults and the elderly. Two thirds of the patients have a history of epileptic seizures.] </nowiki>
     * Fourteen-six-Hz-positive-burst <nowiki>[Burst of arch-shaped waves at 13-17 Hz and/or 5-7-Hz but most commonly at 14 and or 6 Hz seen generally over the posterior temporal and adjacent areas of one or both sides of the head during sleep. The sharp peaks of its component waves are positive with respect to other regions. Amplitude varies but is generally below 75  micro V. Comments: (1) best demonstrated by referential recording using contralateral earlobe or other remote, reference electrodes. (2) This pattern has no established clinical significance.] </nowiki>
     * Six-Hz-spike-slow-wave <nowiki>[Spike and slow wave complexes at 4-7Hz, but mostly at 6 Hz occurring generally in brief bursts bilaterally and synchronously, symmetrically or asymmetrically, and either confined to or of larger amplitude over the posterior or anterior regions of the head. The spike has a strong positive component. Amplitude varies but is generally smaller than that of spike-and slow-wave complexes repeating at slower rates. Comment: this pattern should be distinguished from epileptiform discharges. Synonym: wave and spike phantom.] </nowiki>
     * Rudimentary-spike-wave-complex <nowiki>[Synonym: Pseudo petit mal discharge. Paroxysmal discharge that consists of generalized or nearly generalized high voltage 3 to 4/sec waves with poorly developed spike in the positive trough between the slow waves, occurring in drowsiness only. It is found only in infancy and early childhood when marked hypnagogic rhythmical theta activity is paramount in the drowsy state.]</nowiki>
@@ -187,9 +186,9 @@ This project was supported by the by the National Institute of Mental Health of 
     * Subclinical-rhythmic-EEG-discharge-adults <nowiki>[Subclinical rhythmic EEG discharge of adults (SERDA). A rhythmic pattern seen in the adult age group, mainly in the waking state or drowsiness. It consists of a mixture of frequencies, often predominant in the theta range. The onset may be fairly abrupt with widespread sharp rhythmical theta and occasionally with delta activity. As to the spatial distribution, a maximum of this discharge is usually found over the centroparietal region and especially over the vertex. It may resemble a seizure discharge but is not accompanied by any clinical signs or symptoms.] </nowiki>
     * Rhythmic-temporal-theta-burst-drowsiness <nowiki>[Rhythmic temporal theta burst of drowsiness (RTTD). Characteristic burst of 4-7 Hz waves frequently notched by faster waves, occurring over the temporal regions of the head during drowsiness. Synonym: psychomotor variant pattern. Comment: this is a pattern of drowsiness that is of no clinical significance.]</nowiki>
     * Temporal-slowing-elderly <nowiki>[Focal theta and/or delta activity over the temporal regions, especially the left, in persons over the age of 60. Amplitudes are low/similar to the background activity. Comment: focal temporal theta was found in 20 percent of people between the ages of 40-59 years, and 40 percent of people between 60 and 79 years. One third of people older than 60 years had focal temporal delta activity.] </nowiki>
-    * Breach-rhythm <nowiki>[Rhythmical activity recorded over cranial bone defects. Usually it is in the 6 to 11/sec range, does not respond to movements. ] </nowiki>
+    * Breach-rhythm <nowiki>[Rhythmical activity recorded over cranial bone defects. Usually it is in the 6 to 11/sec range, does not respond to movements.] </nowiki>
     * Other-uncertain-significant-pattern
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 '''EEG-artifact''' <nowiki>[When relevant for the clinical interpretation, artifacts can be scored by specifying the type and the location.]</nowiki>
 
@@ -212,262 +211,262 @@ This project was supported by the by the National Institute of Mental Health of 
 
     * Non-biological-artifact
         ** Power-supply-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[50-60 Hz artifact. Monomorphic waveform due to 50 or 60 Hz A/C power supply.] </nowiki>
-        ** Induction-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Artefacts (usually of high frequency) induced by nearby equipment (like in the intensive care unit). ] </nowiki>
+        ** Induction-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Artifacts (usually of high frequency) induced by nearby equipment (like in the intensive care unit).] </nowiki>
         ** Dialysis-artifact {suggestedTag=Finding-attribute/Significance}
         ** Artificial-ventilation-artifact {suggestedTag=Finding-attribute/Significance}
         ** Electrode-pops-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Are brief discharges with a very steep upslope and shallow fall that occur in all leads which include that electrode.] </nowiki>
         ** Salt-bridge-artifact {suggestedTag=Finding-attribute/Significance} <nowiki>[Typically occurs in 1 channel which may appear isoelectric. Only seen in bipolar montage.] </nowiki>
 
     * Other-EEG-artifact <nowiki> {suggestedTag=Finding-attribute/Significance} </nowiki>
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-'''Polygraphic-channels''' <nowiki>[Changes observed in polygraphic channels can be scored: EOG, Respiration, ECG, EMG, other polygraphic channel (+ free text), and their significance logged (normal, abnormal, no definite abnormality). ]</nowiki>
+'''Polygraphic-channel-finding''' <nowiki>[Changes observed in polygraphic channels can be scored: EOG, Respiration, ECG, EMG, other polygraphic channel (+ free text), and their significance logged (normal, abnormal, no definite abnormality).]</nowiki>
 
     * EOG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [Electrooculography]</nowiki>
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Respiration-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance}</nowiki>
         ** Respiration-oxygen-saturation
             *** <nowiki># {takesValue, valueClass=numericClass}</nowiki>
         ** Respiration-feature
-            *** Apnoe-respiration <nowiki>[Add duration and comments in free text]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** Apnoe-respiration <nowiki>[Add duration and comments in free text.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Hypopnea-respiration <nowiki>[Add duration and comments in free text]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Apnea-hypopnea-index-respiration <nowiki>[events/h.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Apnea-hypopnea-index-respiration <nowiki>[Events/h.]</nowiki>
                 **** Apnea-hypopnea-index-respiration-frequency <nowiki>[events/h (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Periodic-respiration
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Tachypnea-respiration <nowiki>[cycles per min.]</nowiki>
                 **** Tachypnea-respiration-frequency <nowiki>[cycles/min (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-respiration-feature
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-    * ECG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [electrocardiography]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+    * ECG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [Electrocardiography.]</nowiki>
         ** ECG-QT-period
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** ECG-feature
             *** ECG-sinus-rhythm <nowiki>[Normal rhythm.]</nowiki>
-                **** ECG-sinus-rhythm-frequency <nowiki>[beats/min (numbers) typed in.]</nowiki>
+                **** ECG-sinus-rhythm-frequency <nowiki>[Beats/min (number) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-arrhythmia
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** ECG-asystolia <nowiki>[Add duration and comments in free text]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** ECG-asystolia <nowiki>[Add duration and comments in free text.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-bradycardia
-                **** ECG-bradycardia-frequency <nowiki>[beats/min (numbers) typed in.]</nowiki>
+                **** ECG-bradycardia-frequency <nowiki>[Beats/min (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-extrasystole
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-ventricular-premature-depolarization
-                **** ECG-ventricular-premature-depolarization-frequency <nowiki>[beats/min (numbers) typed in.]</nowiki>
+                **** ECG-ventricular-premature-depolarization-frequency <nowiki>[Beats/min (number) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-tachycardia
-                **** ECG-tachycardia-frequency <nowiki>[beats/min (numbers) typed in.]</nowiki>
+                **** ECG-tachycardia-frequency <nowiki>[Beats/min (number) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-ECG-feature
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * EMG-channel-finding <nowiki> {suggestedTag=Finding-attribute/Significance} [electromyography]</nowiki>
         ** EMG-muscle-side
             *** EMG-left-muscle
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-right-muscle
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-bilateral-muscle
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** EMG-muscle-Name
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** EMG-muscle-name
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** EMG-feature
             *** EMG-myoclonus-rhythmic
-                **** EMG-myoclonus-rhythmic-frequency <nowiki>[numbers typed in.]</nowiki>
+                **** EMG-myoclonus-rhythmic-frequency <nowiki>[Numbers typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-myoclonus-arrhythmic
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-myoclonus-synchronous
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-myoclonus-asynchronous
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** EMG-PLMS <nowiki>[Periodic limb movements in sleep] </nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** EMG-PLMS <nowiki>[Periodic limb movements in sleep.] </nowiki>
             *** EMG-spasm
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-tonic-contraction
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-asymmetric-activation-left-first
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** EMG-asymmetric-activation-right-first
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-EMG-features
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Other-polygraphic-channel
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 
-'''Finding-attribute''' <nowiki>[Subtree tree for general properties]</nowiki>
+'''Finding-attribute''' <nowiki>[Subtree tree for general properties.]</nowiki>
 
-    * Finding-significance <nowiki>[Significance of finding. When normal/abnormal could be labeled with base schema Normal/Abnormal tags]</nowiki>
+    * Finding-significance <nowiki>[Significance of finding. When normal/abnormal could be labeled with base schema Normal/Abnormal tags.]</nowiki>
         ** Finding-no-definite-abnormality
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Finding-significance-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Finding-significance-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Finding-stopped-by
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Finding-triggered-by
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
     * Finding-unmodified
-        ** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 
-'''Finding-property''' <nowiki>[Descriptive elements. Similar to main HED /Property Something that pertains to a thing. A characteristic of some entity. A quality or feature regarded as a characteristic or inherent part of someone or something. HED attributes are adjectives or adverbs.]</nowiki>
+'''Finding-property''' <nowiki>[Descriptive element similar to main HED /Property. Something that pertains to a thing. A characteristic of some entity. A quality or feature regarded as a characteristic or inherent part of someone or something. HED attributes are adjectives or adverbs.]</nowiki>
 
     * Signal-morphology-property
         ** Delta-activity-morphology <nowiki>[EEG rhythm in the delta (under 4 Hz) range that does not belong to the posterior dominant rhythm (scored under other organized rhythms).]</nowiki>
-            ***  Delta-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+            ***  Delta-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-            ***  Delta-activity-amplitude <nowiki>[microvolts Values (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=amplitudeUnits}</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Theta-activity-morphology <nowiki>[EEG rhythm in the theta (4-8 Hz) range that does not belong to the posterior dominant rhythm (scored under other organized rhythms).]</nowiki>
-            ***  Theta-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+            ***  Delta-activity-amplitude <nowiki>[Value in microvolts (number) typed in.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=electricPotentialUnits}</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Theta-activity-morphology <nowiki>[EEG rhythm in the theta (4-8 Hz) range that does not belong to the posterior dominant rhythm (scored under other organized rhythm).]</nowiki>
+            ***  Theta-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-            ***  Theta-activity-amplitude <nowiki>[microvolts Values (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=amplitudeUnits}</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            ***  Theta-activity-amplitude <nowiki>[Value in microvolts (number) typed in.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=electricPotentialUnits}</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Alpha-activity-morphology <nowiki>[EEG rhythm in the alpha range (8-13 Hz) which is considered part of the background (ongoing) activity but does not fulfil the criteria of the posterior dominant rhythm (alpha rhythm).]</nowiki>
-            ***  Alpha-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+            ***  Alpha-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-            ***  Alpha-activity-amplitude <nowiki>[microvolts Values (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=amplitudeUnits}</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            ***  Alpha-activity-amplitude <nowiki>[Value in microvolts (number) typed in.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=electricPotentialUnits}</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Beta-activity-morphology <nowiki>[EEG rhythm between 14 and 40 Hz, which is considered part of the background (ongoing) activity but does not fulfil the criteria of the posterior dominant rhythm. Most characteristically: a rhythm from 14 to 40 Hz recorded over the fronto-central regions of the head during wakefulness. Amplitude of the beta rhythm varies but is mostly below 30 microV. Other beta rhythms are most prominent in other locations or are diffuse.]</nowiki>
-            *** Beta-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+            *** Beta-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-            *** Beta-activity-amplitude <nowiki>[microvolts Values (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=amplitudeUnits}</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** Beta-activity-amplitude <nowiki>[Value in microvolts (number) typed in.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=electricPotentialUnits}</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Gamma-activity-morphology
-            ***  Gamma-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+            ***  Gamma-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-            ***  Gamma-activity-amplitude <nowiki>[microvolts Values (numbers) typed in.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=amplitudeUnits}</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            ***  Gamma-activity-amplitude <nowiki>[Value in microvolts (number) typed in.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=numericClass, unitClass=electricPotentialUnits}</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Spike-morphology <nowiki>[A transient, clearly distinguished from background activity, with pointed peak at a conventional paper speed or time scale and duration from 20 to under 70 ms, i.e. 1/50-1/15 s approximately. Main component is generally negative relative to other areas. Amplitude varies. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Spike-morphology <nowiki>[A transient, clearly distinguished from background activity, with pointed peak at a conventional paper speed or time scale and duration from 20 to under 70 ms, i.e. 1/50-1/15 s approximately. Main component is generally negative relative to other areas. Amplitude varies.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Spike-and-slow-wave-morphology <nowiki>[A pattern consisting of a spike followed by a slow wave.]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Runs-of-rapid-spikes-morphology <nowiki>[Bursts of spike discharges at a rate from 10 to 25/sec (in most cases somewhat irregular). The bursts last more than 2 seconds (usually 2 to 10 seconds) and it is typically seen in sleep. Synonyms: rhythmic spikes, generalized paroxysmal fast activity, fast paroxysmal rhythms, grand mal discharge, fast beta activity] </nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Polyspikes-morphology <nowiki>[Two or more consecutive spikes. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Polyspike-and-slow-wave-morphology <nowiki>[Two or more consecutive spikes associated with one or more slow waves. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sharp-wave-morphology <nowiki>[A transient clearly distinguished from background activity, with pointed peak at a conventional paper speed or time scale, and duration of 70-200 ms, i.e. over 1/4-1/5 s approximately. Main component is generally negative relative to other areas. Amplitude varies. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sharp-and-slow-wave-morphology <nowiki>[A sequence of a sharp wave and a slow wave. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Slow-sharp-wave-morphology <nowiki>[A transient that bears all the characteristics of a sharp-wave, but exceeds 200 ms. Synonym: blunted sharp wave. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** High-frequency-oscillation-morphology <nowiki>[HFO]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Runs-of-rapid-spikes-morphology <nowiki>[Bursts of spike discharges at a rate from 10 to 25/sec (in most cases somewhat irregular). The bursts last more than 2 seconds (usually 2 to 10 seconds) and it is typically seen in sleep. Synonyms: rhythmic spikes, generalized paroxysmal fast activity, fast paroxysmal rhythms, grand mal discharge, fast beta activity.] </nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Polyspikes-morphology <nowiki>[Two or more consecutive spikes.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Polyspike-and-slow-wave-morphology <nowiki>[Two or more consecutive spikes associated with one or more slow waves.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Sharp-wave-morphology <nowiki>[A transient clearly distinguished from background activity, with pointed peak at a conventional paper speed or time scale, and duration of 70-200 ms, i.e. over 1/4-1/5 s approximately. Main component is generally negative relative to other areas. Amplitude varies.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Sharp-and-slow-wave-morphology <nowiki>[A sequence of a sharp wave and a slow wave.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Slow-sharp-wave-morphology <nowiki>[A transient that bears all the characteristics of a sharp-wave, but exceeds 200 ms. Synonym: blunted sharp wave.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** High-frequency-oscillation-morphology <nowiki>[HFO.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Hypsarrhythmia-classic-morphology <nowiki>[Abnormal interictal high amplitude waves and a background of irregular spikes.]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Hypsarrhythmia-modified-morphology
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Fast-spike-activity-morphology <nowiki>[A burst consisting of a sequence of spikes. Duration greater than 1 s. Frequency at least in the alpha range.] </nowiki>
         ** Low-voltage-fast-activity-morphology <nowiki>[Refers to the fast, and often recruiting activity which can be recorded at the onset of an ictal discharge, particularly in invasive EEG recording of a seizure.] </nowiki>
         ** Polysharp-waves-morphology <nowiki>[A sequence of two or more sharp-waves.]</nowiki>
 
-        ** Polymorphic-delta-activity-morphology <nowiki>[EEG activity consisting of waves in the delta range (over 250 ms duration for each wave) but of different morphology. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Frontal-intermittent-rhythmic-delta-activity-morphology <nowiki>[Frontal intermittent rhythmic delta activity (FIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 1.5-2.5 Hz over the frontal areas of one or both sides of the head. Comment: most commonly associated with unspecified encephalopathy, in adults. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Occipital-intermittent-rhythmic-delta-activity-morphology  <nowiki>[Occipital intermittent rhythmic delta activity (OIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 2-3 Hz over the occipital or posterior head regions of one or both sides of the head. Frequently blocked or attenuated by opening the eyes. Comment: most commonly associated with unspecified encephalopathy, in children]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Temporal-intermittent-rhythmic-delta-activity-morphology <nowiki>[Temporal intermittent rhythmic delta activity (TIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at over the temporal areas of one side of the head. Comment: most commonly associated with temporal lobe epilepsy. ]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Polymorphic-delta-activity-morphology <nowiki>[EEG activity consisting of waves in the delta range (over 250 ms duration for each wave) but of different morphology.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Frontal-intermittent-rhythmic-delta-activity-morphology <nowiki>[Frontal intermittent rhythmic delta activity (FIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 1.5-2.5 Hz over the frontal areas of one or both sides of the head. Comment: most commonly associated with unspecified encephalopathy, in adults.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Occipital-intermittent-rhythmic-delta-activity-morphology  <nowiki>[Occipital intermittent rhythmic delta activity (OIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 2-3 Hz over the occipital or posterior head regions of one or both sides of the head. Frequently blocked or attenuated by opening the eyes. Comment: most commonly associated with unspecified encephalopathy, in children.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Temporal-intermittent-rhythmic-delta-activity-morphology <nowiki>[Temporal intermittent rhythmic delta activity (TIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at over the temporal areas of one side of the head. Comment: most commonly associated with temporal lobe epilepsy.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Periodic-discharges-morphology <nowiki>[Periodic discharges not further specified (PDs)]</nowiki>
+        ** Periodic-discharges-morphology <nowiki>[Periodic discharges not further specified (PDs).]</nowiki>
             *** Periodic-discharges-superimposed-activity
                 **** Periodic-discharges-fast-superimposed-activity
-                    *****  Periodic-discharges-fast-superimposed-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+                    *****  Periodic-discharges-fast-superimposed-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                         ****** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Periodic-discharges-rhythmic-superimposed-activity
-                    *****  Periodic-discharges-rhythmic-superimposed-activity-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+                    *****  Periodic-discharges-rhythmic-superimposed-activity-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                         ****** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharges-superimposed-activity-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharges-superimposed-activity-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Periodic-discharge-sharpness
                 **** Spiky-periodic-discharge-sharpness
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Sharp-periodic-discharge-sharpness
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Sharply-contoured-periodic-discharge-sharpness
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Blunt-periodic-discharge-sharpness
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-sharpness-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-sharpness-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Number-of-periodic-discharge-phases
                 **** 1-periodic-discharge-phase
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** 2-periodic-discharge-phases
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** 3-periodic-discharge-phases
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Greater-than-3-periodic-discharge-phases
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Number-of-periodic-discharge-phases-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Number-of-periodic-discharge-phases-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Periodic-discharge-triphasic-morphology
                 **** Periodic-discharge-triphasic-morphology-exists
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** No-periodic-discharge-triphasic-morphology
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-triphasic-morphology-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-triphasic-morphology-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Periodic-discharge-absolute-amplitude
-                **** Periodic-discharge-absolute-amplitude-very-low <nowiki>[lower than 20 microV)]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Low-periodic-discharge-absolute-amplitude <nowiki>[20 to 49 microV]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Medium-periodic-discharge-absolute-amplitude <nowiki>[50 to 199 microV]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** High-periodic-discharge-absolute-amplitude <nowiki>[greater than 200 microV]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-absolute-amplitude-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** Periodic-discharge-absolute-amplitude-very-low <nowiki>[Lower than 20 microV.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Low-periodic-discharge-absolute-amplitude <nowiki>[20 to 49 microV.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Medium-periodic-discharge-absolute-amplitude <nowiki>[50 to 199 microV.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** High-periodic-discharge-absolute-amplitude <nowiki>[Greater than 200 microV.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-absolute-amplitude-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-            *** Periodic-discharge-Relative-amplitude
+            *** Periodic-discharge-relative-amplitude
                 **** Periodic-discharge-relative-amplitude-less-than-equal-2
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Periodic-discharge-relative-amplitude-greater-than-2
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-relative-amplitude-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-relative-amplitude-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Periodic-discharge-polarity
                 **** Positive-periodic-discharge-polarity
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Negative-periodic-discharge-polarity
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Unclear-periodic-discharge-polarity
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Source-analysis <nowiki>[How the current in the brain reaches the electrode sensors.]</nowiki>
-        ** Brain-region-source-analysis-laterality <nowiki>[Uses Location-property/Laterality tags] </nowiki>
+        ** Brain-region-source-analysis-laterality <nowiki>[Uses Location-property/Laterality tags.] </nowiki>
         ** Brain-region-source-analysis
             *** Brain-region-source-analysis-frontal-perisylvian-superior-surface
             *** Brain-region-source-analysis-frontal-lateral
@@ -495,330 +494,330 @@ This project was supported by the by the National Institute of Mental Health of 
     * Location-property <nowiki>[Location can be scored for findings. Semiologic finding can also be characterized by the somatotopic modifier (i.e. the part of the body where it occurs). In this respect, laterality (left, right, symmetric, asymmetric, left greater than right, right greater than left), body part (eyelid, face, arm, leg, trunk, visceral, hemi-) and centricity (axial, proximal limb, distal limb) can be scored.]</nowiki>
         ** Brain-laterality
             *** Brain-laterality-left
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-laterality-left-greater-right
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-laterality-right
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-laterality-right-greater-left
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-laterality-midline
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-laterality-diffuse-asynchronous
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Brain-region
             *** Brain-region-frontal
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-region-temporal
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-region-central
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-region-parietal
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-region-occipital
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Body-part
             *** Body-part-eyelid
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Body-part-face
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Body-part-arm
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Body-part-leg
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Body-part-trunk
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Body-part-visceral
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Body-part-hemi
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Brain-centricity
             *** Brain-centricity-axial
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-centricity-proximal-limb
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Brain-centricity-distal-limb
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Sensors <nowiki>[lists all corresponding sensors (electrodes/channels in montage)]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Sensors <nowiki>[Lists all corresponding sensors (electrodes/channels in montage).]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Finding-propagation <nowiki>[When propagation within the graphoelement is observed, first the location of the onset region is scored. Then, the location of the propagation can be noted.]</nowiki>
             *** Finding-propagation-observed
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Finding-propagation-not-observed
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Multifocal-finding <nowiki>[When the same interictal graphoelement is observed bilaterally and at least in three independent locations, can score them using one entry, and choosing multifocal as a descriptor of the locations of the given interictal graphoelements, optionally emphasizing the involved, and the most active sites.] </nowiki>
             *** Multifocal-observed
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Multifocal-not-observed
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Multifocal-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Multifocal-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 
     * Modulators-property <nowiki>[For each described graphoelement, the influence of the modulators can be scored. Only modulators present in the recording are scored.]</nowiki>
         ** Modulators-reactivity <nowiki>[Susceptibility of individual rhythms or the EEG as a whole to change following sensory stimulation or other physiologic actions.]</nowiki>
             *** Modulators-reactive
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Modulators-not-reactive
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Eye-closure-sensitivity <nowiki>[Eye closure sensitivity.]</nowiki>
             *** Eye-closure-sensitivity-exists
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** No-eye-closure-sensitivity
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Eye-opening-passive <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Passive eye opening. Used with base schema Increasing/Decreasing]</nowiki>
-            *** Eye-opening-passive-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Medication-effect-EEG <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications effect on EEG. Used with base schema Increasing/Decreasing]</nowiki>
-            *** Medication-effect-EEG-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Medication-reduction-effect-EEG <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications reduction or withdrawal effect on EEG. Used with base schema Increasing/Decreasing]</nowiki>
-            *** Medication-reduction-effect-EEG-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Auditive-stimuli-effect <nowiki>{suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Used with base schema Increasing/Decreasing]</nowiki>
-            *** Auditive-stimuli-effect-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Nociceptive-stimuli-effect <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Used with base schema Increasing/Decreasing]</nowiki>
-            *** Nociceptive-stimuli-effect-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Eye-opening-passive <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Passive eye opening. Used with base schema Increasing/Decreasing.]</nowiki>
+            *** Eye-opening-passive-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Medication-effect-EEG <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications effect on EEG. Used with base schema Increasing/Decreasing.]</nowiki>
+            *** Medication-effect-EEG-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Medication-reduction-effect-EEG <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications reduction or withdrawal effect on EEG. Used with base schema Increasing/Decreasing.]</nowiki>
+            *** Medication-reduction-effect-EEG-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Auditive-stimuli-effect <nowiki>{suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Used with base schema Increasing/Decreasing.]</nowiki>
+            *** Auditive-stimuli-effect-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Nociceptive-stimuli-effect <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Used with base schema Increasing/Decreasing.]</nowiki>
+            *** Nociceptive-stimuli-effect-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Physical-effort-effect <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Used with base schema Increasing/Decreasing]</nowiki>
-            *** Physical-effort-effect-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
+            *** Physical-effort-effect-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Cognitive-tasks-effect <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Used with base schema Increasing/Decreasing]</nowiki>
-            *** Cognitive-tasks-effect-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Cognitive-task-effect <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified, suggestedTag=Finding-attribute/Finding-triggered-by} [Used with base schema Increasing/Decreasing.]</nowiki>
+            *** Cognitive-task-effect-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Other-modulators-effect-EEG
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Facilitating-factor <nowiki>[Facilitating factors are defined as transient and sporadic endogenous or exogenous elements capable of augmenting seizure incidence (increasing the likelihood of seizure occurrence).]</nowiki>
             *** Facilitating-factor-alcohol
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Facilitating-factor-awake
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Facilitating-factor-catamenial
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Facilitating-factor-fever
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Facilitating-factor-sleep
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Facilitating-factor-sleep-deprived
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Facilitating-factor-other
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Provocative-factors <nowiki>[Provocative factors are defined as transient and sporadic endogenous or exogenous elements capable of evoking/triggering seizures immediately following the exposure to it.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Provocative-factor <nowiki>[Provocative factors are defined as transient and sporadic endogenous or exogenous elements capable of evoking/triggering seizures immediately following the exposure to it.]</nowiki>
             *** Hyperventilation-provoked
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
             *** Reflex-provoked
-                 **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Medication-effect-clinical <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications clinical effect. Used with base schema Increasing/Decreasing]</nowiki>
-        ** Medication-reduction-effect-clinical <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified}  [Medications reduction or withdrawal clinical effect. Used with base schema Increasing/Decreasing]</nowiki>
+                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Medication-effect-clinical <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified} [Medications clinical effect. Used with base schema Increasing/Decreasing.]</nowiki>
+        ** Medication-reduction-effect-clinical <nowiki> {suggestedTag=Finding-attribute/Finding-stopped-by, suggestedTag=Finding-attribute/Finding-unmodified}  [Medications reduction or withdrawal clinical effect. Used with base schema Increasing/Decreasing.]</nowiki>
         ** Other-modulators-effect-clinical
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Intermittent-photic-stimulation-effect
             *** Posterior-stimulus-dependent-intermittent-photic-stimulation-response
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 ****  Posterior-stimulus-dependent-intermittent-photic-stimulation-response-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
             *** Posterior-stimulus-independent-intermittent-photic-stimulation-response-limited <nowiki>[limited to the stimulus-train] </nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 ****  Posterior-stimulus-independent-intermittent-photic-stimulation-response-limited-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
             *** Posterior-stimulus-independent-intermittent-photic-stimulation-response-self-sustained
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 ****  Posterior-stimulus-independent-intermittent-photic-stimulation-response-self-sustained-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
-            *** Generalized-photoparoxysmal-intermittent-photic-stimulation-response-limited <nowiki>[limited to the stimulus-train] </nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** Generalized-photoparoxysmal-intermittent-photic-stimulation-response-limited <nowiki>[Limited to the stimulus-train.] </nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 ****  Generalized-photoparoxysmal-intermittent-photic-stimulation-response-limited-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
             *** Generalized-photoparoxysmal-intermittent-photic-stimulation-response-self-sustained
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 ****  Generalized-photoparoxysmal-intermittent-photic-stimulation-response-self-sustained-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
             *** Activation-of-pre-existing-epileptogenic-area-intermittent-photic-stimulation-effect
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 ****  Activation-of-pre-existing-epileptogenic-area-intermittent-photic-stimulation-effect-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
             *** Unmodified-intermittent-photic-stimulation-effect
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Modulators-effect <nowiki>[Tags for describing the influence of the modulators]</nowiki>
             *** Modulators-effect-continuous-during-NRS <nowiki>[Continuous during non-rapid-eye-movement-sleep (NRS)]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Modulators-effect-only-during
-                **** <nowiki># {takesValue, valueClass=textClass}[Only during Sleep/Awakening/Hyperventilation/Physical effort/Cognitive task. Free text]</nowiki>
-            *** Modulators-effect-change-of-patterns <nowiki>[Change of patterns during sleep/awakening]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Only during Sleep/Awakening/Hyperventilation/Physical effort/Cognitive task. Free text.]</nowiki>
+            *** Modulators-effect-change-of-patterns <nowiki>[Change of patterns during sleep/awakening.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Time-related-features-property <nowiki>[Important to estimate how often an interictal abnormality is seen in the recording.]</nowiki>
-        ** Appearance-mode <nowiki>[Describes how the non-ictal EEG pattern/graphoelement is distributed through the recording]</nowiki>
-            *** Random-appearance-mode <nowiki>[Occurrence of the non-ictal EEG pattern / graphoelement without any rhythmicity / periodicity ]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Periodic-appearance-mode <nowiki>[Non-ictal EEG pattern / graphoelement occurring at an approximately regular rate / interval (generally of 1 to several seconds). ]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Variable-appearance-mode <nowiki>[Occurrence of non-ictal EEG pattern / graphoelements, that is sometimes rhythmic or periodic, other times random, throughout the recording]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Appearance-mode <nowiki>[Describes how the non-ictal EEG pattern/graphoelement is distributed through the recording.]</nowiki>
+            *** Random-appearance-mode <nowiki>[Occurrence of the non-ictal EEG pattern / graphoelement without any rhythmicity / periodicity.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Periodic-appearance-mode <nowiki>[Non-ictal EEG pattern / graphoelement occurring at an approximately regular rate / interval (generally of 1 to several seconds).]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Variable-appearance-mode <nowiki>[Occurrence of non-ictal EEG pattern / graphoelements, that is sometimes rhythmic or periodic, other times random, throughout the recording.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Intermittent-appearance-mode
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Continuous-appearance-mode
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Appearance-mode-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Appearance-mode-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Discharge-pattern <nowiki>[Describes the organization of the EEG signal within the discharge (distinguish between single and repetitive discharges)]</nowiki>
             *** Single-discharge-pattern <nowiki> {suggestedTag=Finding-property/Finding-incidence} [Applies to the intra-burst pattern: a graphoelement that is not repetitive; before and after the graphoelement one can distinguish the background activity.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Rhythmic-trains-or-bursts-discharge-pattern <nowiki> {suggestedTag=Finding-property/Finding-prevalence}[Applies to the intra-burst pattern: a non-ictal graphoelement that repeats itself without returning to the background activity between them. The graphoelements within this repetition occur at approximately constant period.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Rhythmic-trains-or-bursts-discharge-pattern-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Rhythmic-trains-or-bursts-discharge-pattern-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
             *** Arhythmic-trains-or-bursts-discharge-pattern <nowiki> {suggestedTag=Finding-property/Finding-prevalence} [Applies to the intra-burst pattern: a non-ictal graphoelement that repeats itself without returning to the background activity between them. The graphoelements within this repetition occur at inconstant period.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Fragmented-discharge-pattern
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Finding-extent <nowiki>[percentage of occurrence during the recording (background activity and interictal finding)]</nowiki>
+        ** Finding-extent <nowiki>[Percentage of occurrence during the recording (background activity and interictal finding).]</nowiki>
             *** <nowiki># {takesValue, valueClass=numericClass}</nowiki>
 
-        ** Periodic-discharge-time-related-features <nowiki>[Periodic discharges not further specified (PDs) time-relayed features tags]</nowiki>
+        ** Periodic-discharge-time-related-features <nowiki>[Periodic discharges not further specified (PDs) time-relayed features tags.]</nowiki>
             *** Periodic-discharge-duration
-                **** Very-brief-periodic-discharge-duration <nowiki>[less than 10 sec]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Brief-periodic-discharge-duration <nowiki>[10 to 59 sec]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Intermediate-periodic-discharge-duration <nowiki>[1 to 4.9 min]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Long-periodic-discharge-duration <nowiki>[5 to 59 min]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Very-long-periodic-discharge-duration <nowiki>[greater than 1 hour]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-duration-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** Very-brief-periodic-discharge-duration <nowiki>[Less than 10 sec.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Brief-periodic-discharge-duration <nowiki>[10 to 59 sec.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Intermediate-periodic-discharge-duration <nowiki>[1 to 4.9 min.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Long-periodic-discharge-duration <nowiki>[5 to 59 min.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Very-long-periodic-discharge-duration <nowiki>[Greater than 1 hour.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-duration-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Periodic-discharge-onset
                 **** Sudden-periodic-discharge-onset
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Gradual-periodic-discharge-onset
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-onset-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-onset-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Periodic-discharge-dynamics
                 **** Evolving-periodic-discharge-dynamics
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Fluctuating-periodic-discharge-dynamics
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Static-periodic-discharge-dynamics
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Periodic-discharge-dynamics-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Periodic-discharge-dynamics-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-    * Finding-incidence <nowiki>[how often it occurs/time-epoch]</nowiki>
+    * Finding-incidence <nowiki>[How often it occurs/time-epoch.]</nowiki>
         ** Only-once-finding-incidence
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Rare-finding-incidence <nowiki>[less than 1/h]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Uncommon-finding-incidence <nowiki>[1/5 min to 1/h]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Occasional-finding-incidence <nowiki>[1/min to 1/5min]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Frequent-finding-incidence <nowiki>[1/10 s to 1/min]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Abundant-finding-incidence <nowiki>[ greater than 1/10 s)]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Uncommon-finding-incidence <nowiki>[1/5 min to 1/h.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Occasional-finding-incidence <nowiki>[1/min to 1/5min.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Frequent-finding-incidence <nowiki>[1/10 s to 1/min.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Abundant-finding-incidence <nowiki>[Greater than 1/10 s).]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-    * Finding-prevalence <nowiki>[the percentage of the recording covered by the train/burst]</nowiki>
-        ** Rare-finding-prevalence <nowiki>[Less than 1 precents]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Occasional-finding-prevalence <nowiki>[1 to 9 percents]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Frequent-finding-prevalence <nowiki>[10 to 49 precents]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Abundant-finding-prevalence <nowiki>[50 to 89 percents]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-        ** Continuous-finding-prevalence <nowiki>[Greater than 90 precents]</nowiki>
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+    * Finding-prevalence <nowiki>[The percentage of the recording covered by the train/burst.]</nowiki>
+        ** Rare-finding-prevalence <nowiki>[Less than 1 precent.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Occasional-finding-prevalence <nowiki>[1 to 9 percent.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Frequent-finding-prevalence <nowiki>[10 to 49 precent.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Abundant-finding-prevalence <nowiki>[50 to 89 percent.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+        ** Continuous-finding-prevalence <nowiki>[Greater than 90 precent.]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Posterior-dominant-rhythm-property <nowiki>[Posterior dominant rhythm is the most often scored EEG feature in clinical practice. Therefore, there are specific terms that can be chosen for characterizing the PDR.]</nowiki>
 
-        **  Posterior-dominant-rhythm-frequency <nowiki>[Hz Values (numbers) typed in.]</nowiki>
+        **  Posterior-dominant-rhythm-frequency <nowiki>[Value in Hz (number) typed in.]</nowiki>
             *** <nowiki># {takesValue, valueClass=numericClass, unitClass=frequencyUnits}</nowiki>
 
         ** Posterior-dominant-rhythm-amplitude-range
-            *** Low-posterior-dominant-rhythm-amplitude-range <nowiki>[Low (less than 20 microV)]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Medium-posterior-dominant-rhythm-amplitude-range <nowiki>[Medium (between 20 and 70 microV)]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** High-posterior-dominant-rhythm-amplitude-range <nowiki>[High (more than 70 microV)]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-amplitude-range-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** Low-posterior-dominant-rhythm-amplitude-range <nowiki>[Low (less than 20 microV).]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Medium-posterior-dominant-rhythm-amplitude-range <nowiki>[Medium (between 20 and 70 microV).]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** High-posterior-dominant-rhythm-amplitude-range <nowiki>[High (more than 70 microV).]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-amplitude-range-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Posterior-dominant-rhythm-amplitude-asymmetry <nowiki>[A difference in amplitude between the homologous area on opposite sides of the head that consistently exceeds 50 percent. When symmetrical could be labeled with base schema Symmetrical tag]</nowiki>
+        ** Posterior-dominant-rhythm-amplitude-asymmetry <nowiki>[A difference in amplitude between the homologous area on opposite sides of the head that consistently exceeds 50 percent. When symmetrical could be labeled with base schema Symmetrical tag.]</nowiki>
             *** Posterior-dominant-rhythm-amplitude-asymmetry-lower-left <nowiki>[Amplitude lower on the left side.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Posterior-dominant-rhythm-amplitude-asymmetry-lower-right <nowiki>[Amplitude lower on the right side.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-amplitude-asymmetry-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-amplitude-asymmetry-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Posterior-dominant-rhythm-frequency-asymmetry <nowiki>[When symmetrical could be labeled with base schema Symmetrical tag]</nowiki>
+        ** Posterior-dominant-rhythm-frequency-asymmetry <nowiki>[When symmetrical could be labeled with base schema Symmetrical tag.]</nowiki>
             *** Posterior-dominant-rhythm-frequency-asymmetry-lower-left <nowiki>[Hz lower on the left side.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Posterior-dominant-rhythm-frequency-asymmetry-lower-right <nowiki>[Hz lower on the right side.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Posterior-dominant-rhythm-eye-opening-reactivity <nowiki>[Change (disappearance or measurable decrease in amplitude) of a posterior dominant rhythm following eye-opening. Eye closure has the opposite effect.]</nowiki>
-            *** Posterior-dominant-rhythm-eye-opening-reactivity-exists <nowiki>[When annotated Yes]</nowiki>
+            *** Posterior-dominant-rhythm-eye-opening-reactivity-exists <nowiki>[When annotated Yes.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-eye-opening-reactivity-reduced-left <nowiki>[Reduced left side reactivity.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-eye-opening-reactivity-reduced-rigth <nowiki>[Reduced right side reactivity.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-eye-opening-reactivity-reduced-left <nowiki>[Reduced left side reactivity]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-eye-opening-reactivity-reduced-rigth <nowiki>[Reduced right side reactivity]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-eye-opening-reactivity-reduced-both <nowiki>[Reduced reactivity on both sides]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-eye-opening-reactivity-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** Posterior-dominant-rhythm-eye-opening-reactivity-reduced-both <nowiki>[Reduced reactivity on both sides.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-eye-opening-reactivity-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Posterior-dominant-rhythm-organization <nowiki>[When normal could be labeled with base schema Normal tag]</nowiki>
-            *** Posterior-dominant-rhythm-organization-poorly-organized <nowiki>[Poorly organized]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-organization-disorganized <nowiki>[Disorganized]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-            *** Posterior-dominant-rhythm-organization-markedly-disorganized <nowiki>[Markedly disorganized]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+        ** Posterior-dominant-rhythm-organization <nowiki>[When normal could be labeled with base schema Normal tag.]</nowiki>
+            *** Posterior-dominant-rhythm-organization-poorly-organized <nowiki>[Poorly organized.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-organization-disorganized <nowiki>[Disorganized.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+            *** Posterior-dominant-rhythm-organization-markedly-disorganized <nowiki>[Markedly disorganized.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-        ** Posterior-dominant-rhythm-caveat <nowiki>[Caveats to the annotation of PDR]</nowiki>
+        ** Posterior-dominant-rhythm-caveat <nowiki>[Caveat to the annotation of PDR.]</nowiki>
             *** No-posterior-dominant-rhythm-caveat
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Posterior-dominant-rhythm-caveat-only-open-eyes-during-the-recording
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Posterior-dominant-rhythm-caveat-sleep-deprived-caveat
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Posterior-dominant-rhythm-caveat-drowsy
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Posterior-dominant-rhythm-caveat-only-following-hyperventilation
 
-        ** Absence-of-posterior-dominant-rhythm <nowiki>[Reason for absence of PDR]</nowiki>
+        ** Absence-of-posterior-dominant-rhythm <nowiki>[Reason for absence of PDR.]</nowiki>
             *** Absence-of-posterior-dominant-rhythm-artifacts
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Absence-of-posterior-dominant-rhythm-extreme-low-voltage
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Absence-of-posterior-dominant-rhythm-eye-closure-could-not-be-achieved
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Absence-of-posterior-dominant-rhythm-lack-of-awake-period
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Absence-of-posterior-dominant-rhythm-lack-of-compliance
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Absence-of-posterior-dominant-rhythm-other-causes
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Sleep-property
-        ** Sleep-abnormal-amplitude-asymmetry <nowiki>[Absence or consistently marked amplitude asymmetry (greater than 50 precent) of a normal sleep graphoelement]</nowiki>
+        ** Sleep-abnormal-amplitude-asymmetry <nowiki>[Absence or consistently marked amplitude asymmetry (greater than 50 precent) of a normal sleep graphoelement.]</nowiki>
             *** Sleep-abnormal-amplitude-asymmetry-exists
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Sleep-abnormal-amplitude-asymmetry-lower-left <nowiki>[Amplitude lower on the left side.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Sleep-abnormal-amplitude-asymmetry-lower-right <nowiki>[Amplitude lower on the right side.]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Episode-property
         ** Epileptic-seizure-classification <nowiki>[Epileptic seizures are named using the current ILAE seizure classification (Fisher et al., 2017, Beniczky et al., 2017).] </nowiki>
@@ -857,48 +856,48 @@ This project was supported by the by the National Institute of Mental Health of 
                     ***** Semiology-motor-tonic <nowiki>[A sustained increase in muscle contraction lasting a few seconds to minutes.]</nowiki>
                     ***** Semiology-motor-dystonic <nowiki>[Sustained contractions of both agonist and antagonist muscles producing athetoid or twisting movements, which, when prolonged, may produce abnormal postures.]</nowiki>
                     ***** Semiology-motor-epileptic-spasm <nowiki>[A sudden flexion, extension, or mixed extension flexion of predominantly proximal and truncal muscles that is usually more sustained than a myoclonic movement but not so sustained as a tonic seizure (i.e., about 1 s). Limited forms may occur: grimacing, head nodding. Frequent occurrence in clusters.] </nowiki>
-                    ***** Semiology-motor-postural <nowiki>[Adoption of a posture that may be bilaterally symmetric or asymmetric (as in a fencing posture) ]</nowiki>
-                    ***** Semiology-motor-versive <nowiki>[A sustained, forced conjugate ocular, cephalic, and/or truncal rotation or lateral deviation from the midline]</nowiki>
-                    ***** Semiology-motor-clonic <nowiki>[Myoclonus that is regularly repetitive, involves the same muscle groups, at a frequency of about 2 to 3 c/s, and is prolonged. Synonym: rhythmic myoclonus ]</nowiki>
-                    ***** Semiology-motor-myoclonic <nowiki>[Characterized by myoclonus. MYOCLONUS : sudden, brief (lower than 100 ms) involuntary single or multiple contraction(s) of muscles(s) or muscle groups of variable topography (axial, proximal limb, distal)]</nowiki>
-                    ***** Semiology-motor-jacksonian-march <nowiki>[Term indicating spread of clonic movements through contiguous body parts unilaterally ]</nowiki>
-                    ***** Semiology-motor-negative-myoclonus <nowiki>[Characterized by negative myoclonus. NEGATIVE MYOCLONUS: interruption of tonic muscular activity for lower than 500 ms without evidence of preceding myoclonia. ]</nowiki>
-                    ***** Semiology-motor-tonic-clonic <nowiki>[A sequence consisting of a tonic followed by a clonic phase. Variants such as clonic-tonic-clonic may be seen. Asymmetry of limb posture during the tonic phase of a GTC: one arm is rigidly extended at the elbow (often with the fist clenched tightly and flexed at the wrist), whereas the opposite arm is flexed at the elbow. ]</nowiki>
+                    ***** Semiology-motor-postural <nowiki>[Adoption of a posture that may be bilaterally symmetric or asymmetric (as in a fencing posture).]</nowiki>
+                    ***** Semiology-motor-versive <nowiki>[A sustained, forced conjugate ocular, cephalic, and/or truncal rotation or lateral deviation from the midline.]</nowiki>
+                    ***** Semiology-motor-clonic <nowiki>[Myoclonus that is regularly repetitive, involves the same muscle groups, at a frequency of about 2 to 3 c/s, and is prolonged. Synonym: rhythmic myoclonus .]</nowiki>
+                    ***** Semiology-motor-myoclonic <nowiki>[Characterized by myoclonus. MYOCLONUS : sudden, brief (lower than 100 ms) involuntary single or multiple contraction(s) of muscles(s) or muscle groups of variable topography (axial, proximal limb, distal).]</nowiki>
+                    ***** Semiology-motor-jacksonian-march <nowiki>[Term indicating spread of clonic movements through contiguous body parts unilaterally.]</nowiki>
+                    ***** Semiology-motor-negative-myoclonus <nowiki>[Characterized by negative myoclonus. NEGATIVE MYOCLONUS: interruption of tonic muscular activity for lower than 500 ms without evidence of preceding myoclonia.]</nowiki>
+                    ***** Semiology-motor-tonic-clonic <nowiki>[A sequence consisting of a tonic followed by a clonic phase. Variants such as clonic-tonic-clonic may be seen. Asymmetry of limb posture during the tonic phase of a GTC: one arm is rigidly extended at the elbow (often with the fist clenched tightly and flexed at the wrist), whereas the opposite arm is flexed at the elbow.]</nowiki>
                         ****** Semiology-motor-tonic-clonic-without-figure-of-four
                         ****** Semiology-motor-tonic-clonic-with-figure-of-four-extension-left-elbow
                         ****** Semiology-motor-tonic-clonic-with-figure-of-four-extension-right-elbow
                     ***** Semiology-motor-astatic <nowiki>[Loss of erect posture that results from an atonic, myoclonic, or tonic mechanism. Synonym: drop attack.]</nowiki>
-                    ***** Semiology-motor-atonic <nowiki>[Sudden loss or diminution of muscle tone without apparent preceding myoclonic or tonic event lasting greater or equal to 1 to 2 s, involving head, trunk, jaw, or limb musculature. ]</nowiki>
+                    ***** Semiology-motor-atonic <nowiki>[Sudden loss or diminution of muscle tone without apparent preceding myoclonic or tonic event lasting greater or equal to 1 to 2 s, involving head, trunk, jaw, or limb musculature.]</nowiki>
                     ***** Semiology-motor-eye-blinking
                     ***** Semiology-motor-other-elementary-motor
-                        ****** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                        ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Semiology-motor-automatisms
-                    ***** Semiology-motor-automatisms-mimetic <nowiki>[Facial expression suggesting an emotional state, often fear. ]</nowiki>
-                    ***** Semiology-motor-automatisms-oroalimentary <nowiki>[Lip smacking, lip pursing, chewing, licking, tooth grinding, or swallowing. ]</nowiki>
-                    ***** Semiology-motor-automatisms-dacrystic <nowiki>[Bursts of crying. ]</nowiki>
-                    ***** Semiology-motor-automatisms-dyspraxic <nowiki>[Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation]</nowiki>
-                    ***** Semiology-motor-automatisms-manual <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements. ]</nowiki>
-                    ***** Semiology-motor-automatisms-gestural <nowiki>[Semipurposive, asynchronous hand movements. Often unilateral. ]</nowiki>
-                    ***** Semiology-motor-automatisms-pedal <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements. ]</nowiki>
-                    ***** Semiology-motor-automatisms-hypermotor <nowiki>[1. Involves predominantly proximal limb or axial muscles producing irregular sequential ballistic movements, such as pedaling, pelvic thrusting, thrashing, rocking movements. 2. Increase in rate of ongoing movements or inappropriately rapid performance of a movement. ]</nowiki>
-                    ***** Semiology-motor-automatisms-hypokinetic <nowiki>[A decrease in amplitude and/or rate or arrest of ongoing motor activity. ]</nowiki>
-                    ***** Semiology-motor-automatisms-gelastic <nowiki>[Bursts of laughter or giggling, usually without an appropriate affective tone. ]</nowiki>
+                    ***** Semiology-motor-automatisms-mimetic <nowiki>[Facial expression suggesting an emotional state, often fear.]</nowiki>
+                    ***** Semiology-motor-automatisms-oroalimentary <nowiki>[Lip smacking, lip pursing, chewing, licking, tooth grinding, or swallowing.]</nowiki>
+                    ***** Semiology-motor-automatisms-dacrystic <nowiki>[Bursts of crying.]</nowiki>
+                    ***** Semiology-motor-automatisms-dyspraxic <nowiki>[Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation.]</nowiki>
+                    ***** Semiology-motor-automatisms-manual <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
+                    ***** Semiology-motor-automatisms-gestural <nowiki>[Semipurposive, asynchronous hand movements. Often unilateral.]</nowiki>
+                    ***** Semiology-motor-automatisms-pedal <nowiki>[1. Indicates principally distal components, bilateral or unilateral. 2. Fumbling, tapping, manipulating movements.]</nowiki>
+                    ***** Semiology-motor-automatisms-hypermotor <nowiki>[1. Involves predominantly proximal limb or axial muscles producing irregular sequential ballistic movements, such as pedaling, pelvic thrusting, thrashing, rocking movements. 2. Increase in rate of ongoing movements or inappropriately rapid performance of a movement.]</nowiki>
+                    ***** Semiology-motor-automatisms-hypokinetic <nowiki>[A decrease in amplitude and/or rate or arrest of ongoing motor activity.]</nowiki>
+                    ***** Semiology-motor-automatisms-gelastic <nowiki>[Bursts of laughter or giggling, usually without an appropriate affective tone.]</nowiki>
                     ***** Semiology-motor-other-automatisms
-                        ****** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Semiology-motor-behavioral-arrest <nowiki>[Interruption of ongoing motor activity or of ongoing behaviors with fixed gaze, without movement of the head or trunk (oro-alimentary and hand automatisms may continue)]</nowiki>
+                        ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Semiology-motor-behavioral-arrest <nowiki>[Interruption of ongoing motor activity or of ongoing behaviors with fixed gaze, without movement of the head or trunk (oro-alimentary and hand automatisms may continue).]</nowiki>
             *** Semiology-non-motor-manifestation
                 **** Semiology-sensory
-                    ***** Semiology-sensory-headache <nowiki>[Headache occurring in close temporal proximity to the seizure or as the sole seizure manifestation ]</nowiki>
-                    ***** Semiology-sensory-visual  <nowiki>[Flashing or flickering lights, spots, simple patterns, scotomata, or amaurosis. ]</nowiki>
-                    ***** Semiology-sensory-auditory  <nowiki>[Buzzing, drumming sounds or single tones. ]</nowiki>
+                    ***** Semiology-sensory-headache <nowiki>[Headache occurring in close temporal proximity to the seizure or as the sole seizure manifestation.]</nowiki>
+                    ***** Semiology-sensory-visual  <nowiki>[Flashing or flickering lights, spots, simple patterns, scotomata, or amaurosis.]</nowiki>
+                    ***** Semiology-sensory-auditory  <nowiki>[Buzzing, drumming sounds or single tones.]</nowiki>
                     ***** Semiology-sensory-olfactory
-                    ***** Semiology-sensory-gustatory  <nowiki>[Taste sensations including acidic, bitter, salty, sweet, or metallic. ]</nowiki>
+                    ***** Semiology-sensory-gustatory  <nowiki>[Taste sensations including acidic, bitter, salty, sweet, or metallic.]</nowiki>
                     ***** Semiology-sensory-epigastric  <nowiki>[Abdominal discomfort including nausea, emptiness, tightness, churning, butterflies, malaise, pain, and hunger; sensation may rise to chest or throat. Some phenomena may reflect ictal autonomic dysfunction.]</nowiki>
-                    ***** Semiology-sensory-somatosensory  <nowiki>[Tingling, numbness, electric-shock sensation, sense of movement or desire to move. ]</nowiki>
-                    ***** Semiology-sensory-painful <nowiki>[Peripheral (lateralized/bilateral), cephalic, abdominal]</nowiki>
-                    ***** Semiology-sensory-autonomic-sensation  <nowiki>[A sensation consistent with involvement of the autonomic nervous system, including cardiovascular, gastrointestinal,  sudomotor, vasomotor, and thermoregulatory functions. (Thus autonomic aura; cf. autonomic events  3.0). ]</nowiki>
+                    ***** Semiology-sensory-somatosensory  <nowiki>[Tingling, numbness, electric-shock sensation, sense of movement or desire to move.]</nowiki>
+                    ***** Semiology-sensory-painful <nowiki>[Peripheral (lateralized/bilateral), cephalic, abdominal.]</nowiki>
+                    ***** Semiology-sensory-autonomic-sensation  <nowiki>[A sensation consistent with involvement of the autonomic nervous system, including cardiovascular, gastrointestinal,  sudomotor, vasomotor, and thermoregulatory functions. (Thus autonomic aura; cf. autonomic events  3.0).]</nowiki>
                     ***** Semiology-sensory-other
-                        ****** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                        ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Semiology-experiential
                     ***** Semiology-experiential-affective-emotional <nowiki>[Components include fear, depression, joy, and (rarely) anger.]</nowiki>
                     ***** Semiology-experiential-hallucinatory <nowiki>[Composite perceptions without corresponding external stimuli involving visual, auditory, somatosensory, olfactory, and/or gustatory phenomena. Example: hearing  and seeing  people talking.]</nowiki>
@@ -907,30 +906,30 @@ This project was supported by the by the National Institute of Mental Health of 
                         ****** Semiology-experiential-mnemonic-Deja-vu
                         ****** Semiology-experiential-mnemonic-Jamais-vu
                     ***** Semiology-experiential-other
-                        ****** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Semiology-dyscognitive <nowiki>[The term describes events in which (1) disturbance of cognition is the predominant or most apparent feature, and (2a) two or more of the following components are involved, or (2b) involvement of such components remains undetermined. Otherwise, use the more specific term (e.g., mnemonic experiential seizure  or hallucinatory experiential seizure). Components of cognition: ++ perception: symbolic conception of sensory information ++ attention: appropriate selection of a principal perception or task ++ emotion: appropriate affective significance of a perception ++ memory: ability to store and retrieve percepts or concepts ++ executive function: anticipation, selection, monitoring of consequences, and initiation of motor activity including praxis, speech]</nowiki>
+                        ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Semiology-dyscognitive <nowiki>[The term describes events in which (1) disturbance of cognition is the predominant or most apparent feature, and (2a) two or more of the following components are involved, or (2b) involvement of such components remains undetermined. Otherwise, use the more specific term (e.g., mnemonic experiential seizure  or hallucinatory experiential seizure). Components of cognition: ++ perception: symbolic conception of sensory information ++ attention: appropriate selection of a principal perception or task ++ emotion: appropriate affective significance of a perception ++ memory: ability to store and retrieve percepts or concepts ++ executive function: anticipation, selection, monitoring of consequences, and initiation of motor activity including praxis, speech.]</nowiki>
                 **** Semiology-language-related
                     ***** Semiology-language-related-vocalization
                     ***** Semiology-language-related-verbalization
                     ***** Semiology-language-related-dysphasia
                     ***** Semiology-language-related-aphasia
                     *****  Semiology-language-related-other
-                        ****** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                        ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Semiology-autonomic
-                    ***** Semiology-autonomic-pupillary <nowiki>[Mydriasis, miosis (either bilateral or unilateral) ]</nowiki>
+                    ***** Semiology-autonomic-pupillary <nowiki>[Mydriasis, miosis (either bilateral or unilateral).]</nowiki>
                     ***** Semiology-autonomic-hypersalivation <nowiki>[Increase in production of saliva leading to uncontrollable drooling ]</nowiki>
-                    ***** Semiology-autonomic-respiratory-apnoeic <nowiki>[subjective shortness of breath, hyperventilation, stridor, coughing, choking, apnea, oxygen desaturation, neurogenic pulmonary edema ]</nowiki>
-                    ***** Semiology-autonomic-cardiovascular <nowiki>[Modifications of heart rate (tachycardia, bradycardia), cardiac arrhythmias (such as sinus arrhythmia, sinus arrest, supraventricular tachycardia, atrial premature depolarizations, ventricular premature depolarizations, atrio-ventricular block, bundle branch block, atrioventricular nodal escape rhythm, asystole) ]</nowiki>
-                    ***** Semiology-autonomic-gastrointestinal <nowiki>[Nausea, eructation, vomiting, retching, abdominal sensations, abdominal pain, flatulence, spitting, diarrhea ]</nowiki>
-                    ***** Semiology-autonomic-urinary-incontinence <nowiki>[urinary urge (intense urinary urge at the beginning of seizures), urinary incontinence, ictal urination (rare symptom of partial seizures without loss of consciousness) ]</nowiki>
-                    ***** Semiology-autonomic-genital <nowiki>[Sexual auras (erotic thoughts and feelings, sexual arousal and orgasm). Genital auras (unpleasant, sometimes painful, frightening or emotionally neutral somatosensory sensations in the genitals that can be accompanied by ictal orgasm). Sexual automatisms (hypermotor movements consisting of writhing, thrusting, rhythmic movements of the pelvis, arms and legs, sometimes associated with picking and rhythmic manipulation of the groin or genitalia, exhibitionism and masturbation)]</nowiki>
-                    ***** Semiology-autonomic-vasomotor<nowiki>[ Flushing or pallor (may be accompanied by feelings of warmth, cold and pain)]</nowiki>
-                    ***** Semiology-autonomic-sudomotor <nowiki>[Sweating and piloerection ( may be accompanied by feelings of warmth, cold and pain) ]</nowiki>
-                    ***** Semiology-autonomic-thermoregulatory <nowiki>[Hyperthermia, fever ]</nowiki>
+                    ***** Semiology-autonomic-respiratory-apnoeic <nowiki>[subjective shortness of breath, hyperventilation, stridor, coughing, choking, apnea, oxygen desaturation, neurogenic pulmonary edema.]</nowiki>
+                    ***** Semiology-autonomic-cardiovascular <nowiki>[Modifications of heart rate (tachycardia, bradycardia), cardiac arrhythmias (such as sinus arrhythmia, sinus arrest, supraventricular tachycardia, atrial premature depolarizations, ventricular premature depolarizations, atrio-ventricular block, bundle branch block, atrioventricular nodal escape rhythm, asystole).]</nowiki>
+                    ***** Semiology-autonomic-gastrointestinal <nowiki>[Nausea, eructation, vomiting, retching, abdominal sensations, abdominal pain, flatulence, spitting, diarrhea.]</nowiki>
+                    ***** Semiology-autonomic-urinary-incontinence <nowiki>[urinary urge (intense urinary urge at the beginning of seizures), urinary incontinence, ictal urination (rare symptom of partial seizures without loss of consciousness).]</nowiki>
+                    ***** Semiology-autonomic-genital <nowiki>[Sexual auras (erotic thoughts and feelings, sexual arousal and orgasm). Genital auras (unpleasant, sometimes painful, frightening or emotionally neutral somatosensory sensations in the genitals that can be accompanied by ictal orgasm). Sexual automatisms (hypermotor movements consisting of writhing, thrusting, rhythmic movements of the pelvis, arms and legs, sometimes associated with picking and rhythmic manipulation of the groin or genitalia, exhibitionism and masturbation).]</nowiki>
+                    ***** Semiology-autonomic-vasomotor<nowiki>[Flushing or pallor (may be accompanied by feelings of warmth, cold and pain).]</nowiki>
+                    ***** Semiology-autonomic-sudomotor <nowiki>[Sweating and piloerection (may be accompanied by feelings of warmth, cold and pain).]</nowiki>
+                    ***** Semiology-autonomic-thermoregulatory <nowiki>[Hyperthermia, fever.]</nowiki>
                     ***** Semiology-autonomic-other
-                        ****** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                        ****** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Semiology-manifestation-other
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Postictal-semiology
             *** Postictal-semiology-unconscious
@@ -938,109 +937,109 @@ This project was supported by the by the National Institute of Mental Health of 
             *** Postictal-semiology-aphasia-or-dysphasia <nowiki>[Impaired communication involving language without dysfunction of relevant primary motor or sensory pathways, manifested as impaired comprehension, anomia, parahasic errors or a combination of these.]</nowiki>
             *** Postictal-semiology-behavioral-change <nowiki>[Occurring immediately after a aseizure. Including psychosis, hypomanina, obsessive-compulsive behavior.]</nowiki>
             *** Postictal-semiology-hemianopia <nowiki>[Postictal visual loss in a a hemi field.]</nowiki>
-            *** Postictal-semiology-impaired-cognition <nowiki>[Decreased Cognitive performance involving one or more of perception, attention, emotion, memory, execution, praxis, speech]</nowiki>
-            *** Postictal-semiology-dysphoria <nowiki>[Depression, irritability, euphoric mood, fear, anxiety]</nowiki>
+            *** Postictal-semiology-impaired-cognition <nowiki>[Decreased Cognitive performance involving one or more of perception, attention, emotion, memory, execution, praxis, speech.]</nowiki>
+            *** Postictal-semiology-dysphoria <nowiki>[Depression, irritability, euphoric mood, fear, anxiety.]</nowiki>
             *** Postictal-semiology-headache <nowiki>[Headache with features of tension-type or migraine headache that develops within 3 h following the seizure and resolves within 72 h after seizure.]</nowiki>
             *** Postictal-semiology-nose-wiping <nowiki>[Noes-wiping usually within 60 sec of seizure offset, usually with the hand ipsilateral to the seizure onset.]</nowiki>
-            *** Postictal-semiology-anterograde-amnesia <nowiki>[Impaired ability to remember new material]</nowiki>
-            *** Postictal-semiology-retrograde-amnesia <nowiki>[Impaired ability to recall previously remember material]</nowiki>
+            *** Postictal-semiology-anterograde-amnesia <nowiki>[Impaired ability to remember new material.]</nowiki>
+            *** Postictal-semiology-retrograde-amnesia <nowiki>[Impaired ability to recall previously remember material.]</nowiki>
             *** Postictal-semiology-paresis <nowiki>[Todds palsy. Any unilateral postictal dysfunction relating to motor, language, sensory and/or integrative functions.]</nowiki>
             *** Postictal-semiology-sleep <nowiki>[Invincible need to sleep after a seizure.]</nowiki>
             *** Postictal-semiology-unilateral-myoclonic-jerks <nowiki>[unilateral motor phenomena, other then  specified, occurring in postictal phase.]</nowiki>
             *** Postictal-semiology-other-unilateral-motor-phenomena
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Polygraphic-channel-relation-to-episode
             *** Polygraphic-channel-cause-to-episode
             *** Polygraphic-channel-consequence-of-episode
-            *** Polygraphic-channel-relation-to-episode-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** Polygraphic-channel-relation-to-episode-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
         ** Ictal-EEG-patterns
             *** Ictal-EEG-patterns-obscured-by-artifacts
             *** Ictal-EEG-activity
             *** Postictal-EEG-activity
 
-        ** Episode-time-context-property <nowiki>[Additional clinically relevant features related to episodes can be scored under timing and context. If needed, episode duration can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Temporal-value/Duration]</nowiki>
+        ** Episode-time-context-property <nowiki>[Additional clinically relevant features related to episodes can be scored under timing and context. If needed, episode duration can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Temporal-value/Duration.]</nowiki>
             *** Episode-consciousness
                 **** Episode-consciousness-not-tested
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Episode-consciousness-affected
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Episode-consciousness-mildly-affected
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Episode-consciousness-not-affected
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Episode-consciousness-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.</nowiki>
+                **** Episode-consciousness-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Episode-awareness
                 **** Episode-awareness-exists
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** No-episode-awareness
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Episode-awareness-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Episode-awareness-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Clinical-EEG-temporal-relationship
-                **** Clinical-start-followed-EEG <nowiki>[Clinical start, followed by EEG start by X seconds]</nowiki>
+                **** Clinical-start-followed-EEG <nowiki>[Clinical start, followed by EEG start by X seconds.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=timeUnits}</nowiki>
                     ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** EEG-start-followed-clinical <nowiki>[EEG start, followed by clinical start by X seconds]</nowiki>
+                **** EEG-start-followed-clinical <nowiki>[EEG start, followed by clinical start by X seconds.]</nowiki>
                     ***** <nowiki># {takesValue, valueClass=numericClass, unitClass=timeUnits}</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
                 **** Simultaneous-start-clinical-EEG
-                **** Clinical-EEG-temporal-relationship-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** Clinical-EEG-temporal-relationship-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-            *** Episode-event-count <nowiki>[Number of stereotypical episodes during the recording]</nowiki>
+            *** Episode-event-count <nowiki>[Number of stereotypical episodes during the recording.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=numericClass} </nowiki>
-                **** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Episode-event-count-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** <nowiki># {takesValue, valueClass=textClass}[Free text.t]</nowiki>
+                **** Episode-event-count-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-            *** State-episode-start <nowiki>[State at the start of the episode]</nowiki>
+            *** State-episode-start <nowiki>[State at the start of the episode.]</nowiki>
                 **** Episode-start-from-sleep
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Episode-start-from-awake
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** State-episode-start-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** State-episode-start-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Episode-postictal-phase
                 **** <nowiki># {takesValue, valueClass=numericClass, unitClass=timeUnits} </nowiki>
-                **** Episode-postictal-phase-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                **** Episode-postictal-phase-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Episode-prodrome <nowiki>[Prodrome is a preictal phenomenon, and it is defined as a subjective or objective clinical alteration (e.g., ill-localized sensation or agitation) that heralds the onset of an epileptic seizure but does not form part of it (Blume et al., 2001). Therefore, prodrome should be distinguished from aura (which is an ictal phenomenon).]</nowiki>
                 **** Episode-prodrome-exists
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** No-episode-prodrome
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
             *** Episode-tongue-biting
                 **** Episode-tongue-biting-exists
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** No-episode-tongue-biting
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
-            *** Seizure-dynamics <nowiki>[Spatiotemporal dynamics can be scored (evolution in morphology; evolution in frequency; evolution in location)]</nowiki>
+            *** Seizure-dynamics <nowiki>[Spatiotemporal dynamics can be scored (evolution in morphology; evolution in frequency; evolution in location).]</nowiki>
                 **** Seizure-dynamics-evolution-morphology
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Seizure-dynamics-evolution-frequency
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                 **** Seizure-dynamics-evolution-location
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
-                **** Seizure-dynamics-not-possible-to-determine <nowiki>[Not possible to determine]</nowiki>
-                    ***** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
+                **** Seizure-dynamics-not-possible-to-determine <nowiki>[Not possible to determine.]</nowiki>
+                    ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
     * Artifact-significance-to-recording <nowiki>[It is important to score the significance of the described artifacts: recording is not interpretable, recording of reduced diagnostic value, does not interfere with the interpretation of the recording.]</nowiki>
         ** Recording-not-interpretable-due-to-artifact
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Recording-of-reduced-diagnostic-value-due-to-artifact
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** Artifact-does-not-interfere-recording
-            *** <nowiki># {takesValue, valueClass=textClass}[free text]</nowiki>
+            *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
 
 !# end schema
 

--- a/library_schemas/score/prerelease/HED_score_1.0.0.xml
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.xml
@@ -5569,6 +5569,20 @@ This project was supported by the by the National Institute of Mental Health of 
                         </attribute>
                      </node>
                   </node>
+                  <node>
+                     <name>Clinical-EEG-temporal-relationship-notes</name>
+                     <description>Clinical notes to annotate the clinical-EEG temporal relationship.</description>
+                     <node>
+                        <name>#</name>
+                        <attribute>
+                           <name>takesValue</name>
+                        </attribute>
+                        <attribute>
+                           <name>valueClass</name>
+                           <value>textClass</value>
+                        </attribute>
+                     </node>
+                  </node>
                </node>
                <node>
                   <name>Episode-event-count</name>

--- a/library_schemas/score/prerelease/HED_score_1.0.0.xml
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.xml
@@ -3,9 +3,11 @@
    <prologue>This schema is Hierarchical Event Descriptors (HED) Library Schema implementation for Standardized Computer-based Organized Reporting of EEG: SCORE based on the first official release that includes an xsd and requires unit class, unit modifier, value class, schema attribute and property sections.
 Data sharing using standard definitions enables applications of automated tools to optimize analyses, reduce errors, and ultimately to advance the understanding of the human brain.
 This implementation of SCORE in an open-source, machine-readable format using HED to enables its use in machine analysis and mega-analysis.
+
 Reference:
 [1] Beniczky, Sandor, et al. &quot;Standardized computer based organized reporting of EEG: SCORE.&quot; Epilepsia 54.6 (2013).
 [2] Beniczky, Sandor, et al. &quot;Standardized computer based organized reporting of EEG: SCORE second version.&quot; Clinical Neurophysiology 128.11 (2017).
+
 This mediawiki schema was implemented by Tal Pal Attia and Dora Hermes (Mayo Clinic).
 This project was supported by the by the National Institute of Mental Health of the National Institutes of Health under Award Number R01MH122258 (DH). The content is solely the responsibility of the authors and does not necessarily represent the official views of the National Institutes of Health.</prologue>
    <schema>
@@ -37,7 +39,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Hyperventilation-refused-procedure</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -51,7 +53,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Hyperventilation-poor-effort</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -65,7 +67,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Hyperventilation-good-effort</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -79,7 +81,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Hyperventilation-excellent-effort</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -95,7 +97,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Sleep-deprivation</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -109,7 +111,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Sleep-following-sleep-deprivation</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -123,7 +125,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Natural-sleep</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -137,7 +139,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Induced-sleep</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -151,7 +153,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Drowsiness</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -165,7 +167,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Awakening</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -179,7 +181,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Medication-administered-during-recording</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -193,7 +195,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Medication-withdrawal-or-reduction-during-recording</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -207,7 +209,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Manual-eye-closure</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -221,7 +223,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Manual-eye-opening</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -235,7 +237,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Auditory-stimulation</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -249,7 +251,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Nociceptive-stimulation</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -263,7 +265,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Physical-effort</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -274,10 +276,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
          </node>
          <node>
-            <name>Cognitive-tasks</name>
+            <name>Cognitive-task</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -288,10 +290,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
          </node>
          <node>
-            <name>Other-modulators-and-procedures</name>
+            <name>Other-modulator-or-procedure</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -314,11 +316,11 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>EEG rhythm at 7-11 Hz composed of arch-shaped waves occurring over the central or centro-parietal regions of the scalp during wakefulness. Amplitudes varies but is mostly below 50 microV. Blocked or attenuated most clearly by contralateral movement, thought of movement, readiness to move or tactile stimulation.</description>
          </node>
          <node>
-            <name>Other-organized-rhythms</name>
-            <description>EEG activity that consisting of waves of approximately constant period, which is considered as part of the background (ongoing) activity, but does not fulfil the criteria of the posterior dominant rhythm.</description>
+            <name>Other-organized-rhythm</name>
+            <description>EEG activity that consisting of waves of approximately constant period, which is considered as part of the background (ongoing) activity, but does not fulfill the criteria of the posterior dominant rhythm.</description>
          </node>
          <node>
-            <name>Special-background-activity-features</name>
+            <name>Special-background-activity-feature</name>
             <description>Special Features. Special features contains scoring options for the background activity of critically ill patients.</description>
             <node>
                <name>Continuous-background-activity</name>
@@ -354,7 +356,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>For longer recordings. Only to be scored if whole-night sleep is part of the recording. It is a global descriptor of the structure and pattern of sleep: estimation of the amount of time spent in REM and NREM sleep, sleep duration, NREM-REM cycle.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
             <node>
                <name>Normal-sleep-architecture</name>
@@ -364,10 +366,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Sleep-architecture-not-possible-to-determine</name>
-               <description>Not possible to determine</description>
+               <description>Not possible to determine.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -383,10 +385,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>For normal sleep patterns the sleep stages reached during the recording can be specified</description>
             <node>
                <name>Sleep-stage-N1</name>
-               <description>Sleep stage 1</description>
+               <description>Sleep stage 1.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -398,10 +400,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Sleep-stage-N2</name>
-               <description>Sleep stage 2</description>
+               <description>Sleep stage 2.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -413,10 +415,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Sleep-stage-N3</name>
-               <description>Sleep stage 3</description>
+               <description>Sleep stage 3.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -428,10 +430,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Sleep-stage-REM</name>
-               <description>Rapid eye movement</description>
+               <description>Rapid eye movement.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -443,10 +445,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Sleep-stage-not-possible-to-determine</name>
-               <description>Not possible to determine</description>
+               <description>Not possible to determine.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -462,7 +464,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>Burst at 11-15 Hz but mostly at 12-14 Hz generally diffuse but of higher voltage over the central regions of the head, occurring during sleep. Amplitude varies but is mostly below 50 microV in the adult.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
          <node>
@@ -470,7 +472,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>Sharp potential, maximal at the vertex, negative relative to other areas, apparently occurring spontaneously during sleep or in response to a sensory stimulus during sleep or wakefulness. May be single or repetitive. Amplitude varies but rarely exceeds 250 microV. Abbreviation: V wave. Synonym: vertex sharp wave.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
          <node>
@@ -478,14 +480,14 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>A burst of somewhat variable appearance, consisting most commonly of a high voltage negative slow wave followed by a smaller positive slow wave frequently associated with a sleep spindle. Duration greater than 0.5 s. Amplitude is generally maximal in the frontal vertex. K complexes occur during nonREM sleep, apparently spontaneously, or in response to sudden sensory / auditory stimuli, and are not specific for any individual sensory modality.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
          <node>
             <name>Sleep-saw-tooth-waves</name>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
          <node>
@@ -493,7 +495,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>Positive occipital sharp transients of sleep. Sharp transient maximal over the occipital regions, positive relative to other areas, apparently occurring spontaneously during sleep. May be single or repetitive. Amplitude varies but is generally bellow 50 microV.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
          <node>
@@ -501,7 +503,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>Bursts of bilateral, synchronous delta or theta activity of large amplitude, occasionally with superimposed faster components, occurring during falling asleep or during awakening, in children.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
          <node>
@@ -509,13 +511,13 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>EEG activity consisting of normal sleep graphoelemts, but which cannot be interrupted by external stimuli/ the patient cannot be waken.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
          </node>
       </node>
       <node>
-         <name>Interictal-findings</name>
-         <description>EEG patterns / transients that are distinguished form the background activity, considered abnormal, but are not recorded during ictal period (seizure) or postictal period; the presence of interictal findings does not necessarily imply that the patient has epilepsy.</description>
+         <name>Interictal-finding</name>
+         <description>EEG pattern / transient that is distinguished form the background activity, considered abnormal, but is not recorded during ictal period (seizure) or postictal period; the presence of an interictal finding does not necessarily imply that the patient has epilepsy.</description>
          <node>
             <name>Epileptiform-interictal-activity</name>
          </node>
@@ -525,24 +527,24 @@ This project was supported by the by the National Institute of Mental Health of 
          <node>
             <name>Interictal-special-patterns</name>
             <node>
-               <name>Interictal-periodic-discharges</name>
-               <description>Periodic discharges not further specified (PDs).</description>
+               <name>Interictal-periodic-discharge</name>
+               <description>Periodic discharge not further specified (PD).</description>
             </node>
             <node>
-               <name>Generalized-periodic-discharges</name>
-               <description>GPDs</description>
+               <name>Generalized-periodic-discharge</name>
+               <description>GPD.</description>
             </node>
             <node>
-               <name>Lateralized-periodic-discharges</name>
-               <description>LPDs</description>
+               <name>Lateralized-periodic-discharge</name>
+               <description>LPD.</description>
             </node>
             <node>
-               <name>Bilateral-independent-periodic-discharges</name>
-               <description>BIPDs</description>
+               <name>Bilateral-independent-periodic-discharge</name>
+               <description>BIPD.</description>
             </node>
             <node>
-               <name>Multifocal-periodic-discharges</name>
-               <description>MfPDs</description>
+               <name>Multifocal-periodic-discharge</name>
+               <description>MfPD.</description>
             </node>
             <node>
                <name>Interictal-extreme-delta-brush</name>
@@ -557,7 +559,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </node>
       <node>
          <name>Episode</name>
-         <description>Clinical episodes or electrographic seizures.</description>
+         <description>Clinical episode or electrographic seizure.</description>
          <node>
             <name>Epileptic-seizure</name>
             <node>
@@ -587,21 +589,21 @@ This project was supported by the by the National Institute of Mental Health of 
          </node>
          <node>
             <name>Subtle-seizure</name>
-            <description>Seizure type frequent in neonates, sometimes referred to as motor automatism; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges , and are clearly epileptic, ictal EEG often does not show typical epileptic activity</description>
+            <description>Seizure type frequent in neonates, sometimes referred to as motor automatism; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges, and are clearly epileptic, ictal EEG often does not show typical epileptic activity.</description>
          </node>
          <node>
             <name>Electrographic-seizure</name>
-            <description>Referred usually to non convulsive status. Ictal EEG: rhythmic discharge or spike and wave pattern with definite evolution in frequency, location, or morphology lasting at least 10 s; evolution in amplitude alone did not qualify</description>
+            <description>Referred usually to non convulsive status. Ictal EEG: rhythmic discharge or spike and wave pattern with definite evolution in frequency, location, or morphology lasting at least 10 s; evolution in amplitude alone did not qualify.</description>
          </node>
          <node>
             <name>Seizure-PNES</name>
-            <description>Psychogenic non-epileptic seizure</description>
+            <description>Psychogenic non-epileptic seizure.</description>
          </node>
          <node>
-            <name>Sleep-related-episodes</name>
+            <name>Sleep-related-episode</name>
             <node>
                <name>Sleep-related-arousal</name>
-               <description>Normal</description>
+               <description>Normal.</description>
             </node>
             <node>
                <name>Benign-sleep-myoclonus</name>
@@ -609,11 +611,11 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Confusional-awakening</name>
-               <description>Episodes of non epileptic nature included in NREM parasomnias, characterized by sudden arousal and complex behavior but without full alertness, usually lasting a few minutes and occurring almost in all children at least occasionally. Amnesia of the episode is the rule.</description>
+               <description>Episode of non epileptic nature included in NREM parasomnias, characterized by sudden arousal and complex behavior but without full alertness, usually lasting a few minutes and occurring almost in all children at least occasionally. Amnesia of the episode is the rule.</description>
             </node>
             <node>
                <name>Sleep-periodic-limb-movement</name>
-               <description>PLMS. Periodic limb movement in sleep. Episodes characterized by brief (0.5- to 5.0-second) lower-extremity movements during sleep, which typically occur at 20- to 40-second intervals, most commonly during the first 3 hours of sleep. The affected individual is usually not aware of the movements or of the transient partial arousals.</description>
+               <description>PLMS. Periodic limb movement in sleep. Episodes are characterized by brief (0.5- to 5.0-second) lower-extremity movements during sleep, which typically occur at 20- to 40-second intervals, most commonly during the first 3 hours of sleep. The affected individual is usually not aware of the movements or of the transient partial arousals.</description>
             </node>
             <node>
                <name>REM-sleep-behavioral-disorder</name>
@@ -625,7 +627,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
          </node>
          <node>
-            <name>Pediatric-episodes</name>
+            <name>Pediatric-episode</name>
             <node>
                <name>Hyperekplexia</name>
                <description>Disorder characterized by exaggerated startle response and hypertonicity that may occur during the first year of life and in severe cases during the neonatal period. Children usually present with marked irritability and recurrent startles in response to handling and sounds. Severely affected infants can have severe jerks and stiffening, sometimes with breath-holding spells.</description>
@@ -636,7 +638,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Pavor-nocturnus</name>
-               <description>Nocturnal episodes characterized by age of onset of less than five years (mean age 18 months, with peak prevalence at five to seven years), appearance of signs of panic two hours after falling asleep with crying, screams, a fearful expression, inability to recognize other people including parents (for a duration of 5-15 minutes), amnesia upon awakening. Pavor nocturnus occurs in patients almost every night for months or years (but the frequency is highly variable and may be as low as once a month) and is likely to disappear spontaneously at the age of six to eight years.</description>
+               <description>A nocturnal episode characterized by age of onset of less than five years (mean age 18 months, with peak prevalence at five to seven years), appearance of signs of panic two hours after falling asleep with crying, screams, a fearful expression, inability to recognize other people including parents (for a duration of 5-15 minutes), amnesia upon awakening. Pavor nocturnus occurs in patients almost every night for months or years (but the frequency is highly variable and may be as low as once a month) and is likely to disappear spontaneously at the age of six to eight years.</description>
             </node>
             <node>
                <name>Pediatric-stereotypical-behavior-episode</name>
@@ -659,7 +661,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Other-episode</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -675,7 +677,7 @@ This project was supported by the by the National Institute of Mental Health of 
          <description>EEG graphoelements or rhythms that are considered normal. They only should be scored if the physician considers that they have a specific clinical significance for the recording.</description>
          <node>
             <name>Rhythmic-activity-pattern</name>
-            <description>Not further specified</description>
+            <description>Not further specified.</description>
          </node>
          <node>
             <name>Slow-alpha-variant-rhythm</name>
@@ -737,7 +739,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Other-physiologic-pattern</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -802,7 +804,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Other-uncertain-significant-pattern</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -823,7 +825,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Fp1/Fp2 become electropositive with eye closure because the cornea is positively charged causing a negative deflection in Fp1/Fp2. If the eye blink is unilateral, consider prosthetic eye. If it is in F8 rather than Fp2 then the electrodes are plugged in wrong.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -831,7 +833,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>There is an upward deflection in the Fp2-F8 derivation, when the eyes move to the right side. In this case F8 becomes more positive and therefore. When the eyes move to the left, F7 becomes more positive and there is an upward deflection in the Fp1-F7 derivation.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -839,7 +841,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>The EEG shows positive potentials (50-100 micro V) with bi-frontal distribution, maximum at Fp1 and Fp2, when the eyeball rotated upward. The downward rotation of the eyeball was associated with the negative deflection. The time course of the deflections was similar to the time course of the eyeball movement.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -847,28 +849,28 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Slow, rolling eye-movements, seen during drowsiness.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
                <name>Nystagmus-artifact</name>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
                <name>Chewing-artifact</name>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
                <name>Sucking-artifact</name>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -876,7 +878,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>The tongue functions as a dipole, with the tip negative with respect to the base. The artifact produced by the tongue has a broad potential field that drops from frontal to occipital areas, although it is less steep than that produced by eye movement artifacts. The amplitude of the potentials is greater inferiorly than in parasagittal regions; the frequency is variable but usually in the delta range. Chewing and sucking can produce similar artifacts.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -884,7 +886,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Quasi-rhythmical artifacts in recordings from infants caused by rocking/ patting.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -892,7 +894,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Large amplitude artifact, with irregular morphology (usually resembling a slow-wave or a wave with complex morphology) seen in one or several channels, due to movement. If the causing movement is repetitive, the artifact might resemble a rhythmic EEG activity.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -900,7 +902,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Respiration can produce 2 kinds of artifacts. One type is in the form of slow and rhythmic activity, synchronous with the body movements of respiration and mechanically affecting the impedance of (usually) one electrode. The other type can be slow or sharp waves that occur synchronously with inhalation or exhalation and involve those electrodes on which the patient is lying.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -908,7 +910,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Occurs when an EEG electrode is placed over a pulsating vessel. The pulsation can cause slow waves that may simulate EEG activity. A direct relationship exists between ECG and the pulse waves (200-300 millisecond delay after ECG equals QRS complex).</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -916,7 +918,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Far-field potential generated in the heart. The voltage and apparent surface of the artifact vary from derivation to derivation and, consequently, from montage to montage. The artifact is observed best in referential montages using earlobe electrodes A1 and A2. ECG artifact is recognized easily by its rhythmicity/regularity and coincidence with the ECG tracing.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -924,7 +926,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Is a low amplitude undulating waveform that is usually greater than 2 seconds and may appear to be an unstable baseline.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -932,7 +934,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Myogenic potentials are the most common artifacts. Frontalis and temporalis muscles (ex..: clenching of jaw muscles) are common causes. Generally, the potentials generated in the muscles are of shorter duration than those generated in the brain. The frequency components are usually beyond 30-50 Hz, and the bursts are arrhythmic.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
          </node>
@@ -943,29 +945,29 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>50-60 Hz artifact. Monomorphic waveform due to 50 or 60 Hz A/C power supply.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
                <name>Induction-artifact</name>
-               <description>Artefacts (usually of high frequency) induced by nearby equipment (like in the intensive care unit).</description>
+               <description>Artifacts (usually of high frequency) induced by nearby equipment (like in the intensive care unit).</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
                <name>Dialysis-artifact</name>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
                <name>Artificial-ventilation-artifact</name>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -973,7 +975,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Are brief discharges with a very steep upslope and shallow fall that occur in all leads which include that electrode.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
             <node>
@@ -981,7 +983,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Typically occurs in 1 channel which may appear isoelectric. Only seen in bipolar montage.</description>
                <attribute>
                   <name>suggestedTag</name>
-                  <value>Finding-attribute/Significance</value>
+                  <value>Finding-significance</value>
                </attribute>
             </node>
          </node>
@@ -989,11 +991,11 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Other-EEG-artifact</name>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -1005,18 +1007,18 @@ This project was supported by the by the National Institute of Mental Health of 
          </node>
       </node>
       <node>
-         <name>Polygraphic-channels</name>
+         <name>Polygraphic-channel-finding</name>
          <description>Changes observed in polygraphic channels can be scored: EOG, Respiration, ECG, EMG, other polygraphic channel (+ free text), and their significance logged (normal, abnormal, no definite abnormality).</description>
          <node>
             <name>EOG-channel-finding</name>
             <description>Electrooculography</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -1030,7 +1032,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Respiration-channel-finding</name>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
             <node>
                <name>Respiration-oxygen-saturation</name>
@@ -1049,10 +1051,10 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Respiration-feature</name>
                <node>
                   <name>Apnoe-respiration</name>
-                  <description>Add duration and comments in free text</description>
+                  <description>Add duration and comments in free text.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1067,7 +1069,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Add duration and comments in free text</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1079,14 +1081,14 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Apnea-hypopnea-index-respiration</name>
-                  <description>events/h.</description>
+                  <description>Events/h.</description>
                   <node>
                      <name>Apnea-hypopnea-index-respiration-frequency</name>
                      <description>events/h (numbers) typed in.</description>
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1100,7 +1102,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Periodic-respiration</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1119,7 +1121,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1133,7 +1135,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Other-respiration-feature</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1147,16 +1149,16 @@ This project was supported by the by the National Institute of Mental Health of 
          </node>
          <node>
             <name>ECG-channel-finding</name>
-            <description>electrocardiography</description>
+            <description>Electrocardiography.</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
             <node>
                <name>ECG-QT-period</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1173,7 +1175,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Normal rhythm.</description>
                   <node>
                      <name>ECG-sinus-rhythm-frequency</name>
-                     <description>beats/min (numbers) typed in.</description>
+                     <description>Beats/min (number) typed in.</description>
                      <node>
                         <name>#</name>
                         <attribute>
@@ -1191,7 +1193,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1205,7 +1207,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>ECG-arrhythmia</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1217,10 +1219,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>ECG-asystolia</name>
-                  <description>Add duration and comments in free text</description>
+                  <description>Add duration and comments in free text.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1234,7 +1236,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>ECG-bradycardia</name>
                   <node>
                      <name>ECG-bradycardia-frequency</name>
-                     <description>beats/min (numbers) typed in.</description>
+                     <description>Beats/min (numbers) typed in.</description>
                      <node>
                         <name>#</name>
                         <attribute>
@@ -1252,7 +1254,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1266,7 +1268,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>ECG-extrasystole</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1280,7 +1282,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>ECG-ventricular-premature-depolarization</name>
                   <node>
                      <name>ECG-ventricular-premature-depolarization-frequency</name>
-                     <description>beats/min (numbers) typed in.</description>
+                     <description>Beats/min (number) typed in.</description>
                      <node>
                         <name>#</name>
                         <attribute>
@@ -1298,7 +1300,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1312,7 +1314,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>ECG-tachycardia</name>
                   <node>
                      <name>ECG-tachycardia-frequency</name>
-                     <description>beats/min (numbers) typed in.</description>
+                     <description>Beats/min (number) typed in.</description>
                      <node>
                         <name>#</name>
                         <attribute>
@@ -1330,7 +1332,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1344,7 +1346,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Other-ECG-feature</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1361,7 +1363,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>electromyography</description>
             <attribute>
                <name>suggestedTag</name>
-               <value>Finding-attribute/Significance</value>
+               <value>Finding-significance</value>
             </attribute>
             <node>
                <name>EMG-muscle-side</name>
@@ -1369,7 +1371,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-left-muscle</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1383,7 +1385,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-right-muscle</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1397,7 +1399,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-bilateral-muscle</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1409,10 +1411,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
             </node>
             <node>
-               <name>EMG-muscle-Name</name>
+               <name>EMG-muscle-name</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1428,7 +1430,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-myoclonus-rhythmic</name>
                   <node>
                      <name>EMG-myoclonus-rhythmic-frequency</name>
-                     <description>numbers typed in.</description>
+                     <description>Numbers typed in.</description>
                      <node>
                         <name>#</name>
                         <attribute>
@@ -1446,7 +1448,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1460,7 +1462,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-myoclonus-arrhythmic</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1474,7 +1476,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-myoclonus-synchronous</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1488,7 +1490,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-myoclonus-asynchronous</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1500,13 +1502,13 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>EMG-PLMS</name>
-                  <description>Periodic limb movements in sleep</description>
+                  <description>Periodic limb movements in sleep.</description>
                </node>
                <node>
                   <name>EMG-spasm</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1520,7 +1522,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-tonic-contraction</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1534,7 +1536,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-asymmetric-activation-left-first</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1548,7 +1550,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>EMG-asymmetric-activation-right-first</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1562,7 +1564,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Other-EMG-features</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -1578,7 +1580,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Other-polygraphic-channel</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -1591,15 +1593,15 @@ This project was supported by the by the National Institute of Mental Health of 
       </node>
       <node>
          <name>Finding-attribute</name>
-         <description>Subtree tree for general properties</description>
+         <description>Subtree tree for general properties.</description>
          <node>
             <name>Finding-significance</name>
-            <description>Significance of finding. When normal/abnormal could be labeled with base schema Normal/Abnormal tags</description>
+            <description>Significance of finding. When normal/abnormal could be labeled with base schema Normal/Abnormal tags.</description>
             <node>
                <name>Finding-no-definite-abnormality</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1611,10 +1613,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Finding-significance-not-possible-to-determine</name>
-               <description>Not possible to determine</description>
+               <description>Not possible to determine.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1629,7 +1631,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Finding-stopped-by</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -1643,7 +1645,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Finding-triggered-by</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -1657,7 +1659,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Finding-unmodified</name>
             <node>
                <name>#</name>
-               <description>free text</description>
+               <description>Free text.</description>
                <attribute>
                   <name>takesValue</name>
                </attribute>
@@ -1670,7 +1672,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </node>
       <node>
          <name>Finding-property</name>
-         <description>Descriptive elements. Similar to main HED /Property Something that pertains to a thing. A characteristic of some entity. A quality or feature regarded as a characteristic or inherent part of someone or something. HED attributes are adjectives or adverbs.</description>
+         <description>Descriptive element similar to main HED /Property. Something that pertains to a thing. A characteristic of some entity. A quality or feature regarded as a characteristic or inherent part of someone or something. HED attributes are adjectives or adverbs.</description>
          <node>
             <name>Signal-morphology-property</name>
             <node>
@@ -1678,7 +1680,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>EEG rhythm in the delta (under 4 Hz) range that does not belong to the posterior dominant rhythm (scored under other organized rhythms).</description>
                <node>
                   <name>Delta-activity-frequency</name>
-                  <description>Hz Values (numbers) typed in.</description>
+                  <description>Value in Hz (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1696,7 +1698,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Delta-activity-amplitude</name>
-                  <description>microvolts Values (numbers) typed in.</description>
+                  <description>Value in microvolts (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1708,13 +1710,13 @@ This project was supported by the by the National Institute of Mental Health of 
                      </attribute>
                      <attribute>
                         <name>unitClass</name>
-                        <value>amplitudeUnits</value>
+                        <value>electricPotentialUnits</value>
                      </attribute>
                   </node>
                </node>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1726,10 +1728,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Theta-activity-morphology</name>
-               <description>EEG rhythm in the theta (4-8 Hz) range that does not belong to the posterior dominant rhythm (scored under other organized rhythms).</description>
+               <description>EEG rhythm in the theta (4-8 Hz) range that does not belong to the posterior dominant rhythm (scored under other organized rhythm).</description>
                <node>
                   <name>Theta-activity-frequency</name>
-                  <description>Hz Values (numbers) typed in.</description>
+                  <description>Value in Hz (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1747,7 +1749,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Theta-activity-amplitude</name>
-                  <description>microvolts Values (numbers) typed in.</description>
+                  <description>Value in microvolts (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1759,13 +1761,13 @@ This project was supported by the by the National Institute of Mental Health of 
                      </attribute>
                      <attribute>
                         <name>unitClass</name>
-                        <value>amplitudeUnits</value>
+                        <value>electricPotentialUnits</value>
                      </attribute>
                   </node>
                </node>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1780,7 +1782,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>EEG rhythm in the alpha range (8-13 Hz) which is considered part of the background (ongoing) activity but does not fulfil the criteria of the posterior dominant rhythm (alpha rhythm).</description>
                <node>
                   <name>Alpha-activity-frequency</name>
-                  <description>Hz Values (numbers) typed in.</description>
+                  <description>Value in Hz (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1798,7 +1800,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Alpha-activity-amplitude</name>
-                  <description>microvolts Values (numbers) typed in.</description>
+                  <description>Value in microvolts (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1810,13 +1812,13 @@ This project was supported by the by the National Institute of Mental Health of 
                      </attribute>
                      <attribute>
                         <name>unitClass</name>
-                        <value>amplitudeUnits</value>
+                        <value>electricPotentialUnits</value>
                      </attribute>
                   </node>
                </node>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1831,7 +1833,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>EEG rhythm between 14 and 40 Hz, which is considered part of the background (ongoing) activity but does not fulfil the criteria of the posterior dominant rhythm. Most characteristically: a rhythm from 14 to 40 Hz recorded over the fronto-central regions of the head during wakefulness. Amplitude of the beta rhythm varies but is mostly below 30 microV. Other beta rhythms are most prominent in other locations or are diffuse.</description>
                <node>
                   <name>Beta-activity-frequency</name>
-                  <description>Hz Values (numbers) typed in.</description>
+                  <description>Value in Hz (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1849,7 +1851,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Beta-activity-amplitude</name>
-                  <description>microvolts Values (numbers) typed in.</description>
+                  <description>Value in microvolts (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1861,13 +1863,13 @@ This project was supported by the by the National Institute of Mental Health of 
                      </attribute>
                      <attribute>
                         <name>unitClass</name>
-                        <value>amplitudeUnits</value>
+                        <value>electricPotentialUnits</value>
                      </attribute>
                   </node>
                </node>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1881,7 +1883,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Gamma-activity-morphology</name>
                <node>
                   <name>Gamma-activity-frequency</name>
-                  <description>Hz Values (numbers) typed in.</description>
+                  <description>Value in Hz (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1899,7 +1901,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Gamma-activity-amplitude</name>
-                  <description>microvolts Values (numbers) typed in.</description>
+                  <description>Value in microvolts (number) typed in.</description>
                   <node>
                      <name>#</name>
                      <attribute>
@@ -1911,13 +1913,13 @@ This project was supported by the by the National Institute of Mental Health of 
                      </attribute>
                      <attribute>
                         <name>unitClass</name>
-                        <value>amplitudeUnits</value>
+                        <value>electricPotentialUnits</value>
                      </attribute>
                   </node>
                </node>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1932,7 +1934,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>A transient, clearly distinguished from background activity, with pointed peak at a conventional paper speed or time scale and duration from 20 to under 70 ms, i.e. 1/50-1/15 s approximately. Main component is generally negative relative to other areas. Amplitude varies.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1947,7 +1949,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>A pattern consisting of a spike followed by a slow wave.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1959,10 +1961,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Runs-of-rapid-spikes-morphology</name>
-               <description>Bursts of spike discharges at a rate from 10 to 25/sec (in most cases somewhat irregular). The bursts last more than 2 seconds (usually 2 to 10 seconds) and it is typically seen in sleep. Synonyms: rhythmic spikes, generalized paroxysmal fast activity, fast paroxysmal rhythms, grand mal discharge, fast beta activity</description>
+               <description>Bursts of spike discharges at a rate from 10 to 25/sec (in most cases somewhat irregular). The bursts last more than 2 seconds (usually 2 to 10 seconds) and it is typically seen in sleep. Synonyms: rhythmic spikes, generalized paroxysmal fast activity, fast paroxysmal rhythms, grand mal discharge, fast beta activity.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1977,7 +1979,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Two or more consecutive spikes.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -1992,7 +1994,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Two or more consecutive spikes associated with one or more slow waves.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2007,7 +2009,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>A transient clearly distinguished from background activity, with pointed peak at a conventional paper speed or time scale, and duration of 70-200 ms, i.e. over 1/4-1/5 s approximately. Main component is generally negative relative to other areas. Amplitude varies.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2022,7 +2024,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>A sequence of a sharp wave and a slow wave.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2037,7 +2039,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>A transient that bears all the characteristics of a sharp-wave, but exceeds 200 ms. Synonym: blunted sharp wave.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2049,10 +2051,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>High-frequency-oscillation-morphology</name>
-               <description>HFO</description>
+               <description>HFO.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2067,7 +2069,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Abnormal interictal high amplitude waves and a background of irregular spikes.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2081,7 +2083,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Hypsarrhythmia-modified-morphology</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2108,7 +2110,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>EEG activity consisting of waves in the delta range (over 250 ms duration for each wave) but of different morphology.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2123,7 +2125,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Frontal intermittent rhythmic delta activity (FIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 1.5-2.5 Hz over the frontal areas of one or both sides of the head. Comment: most commonly associated with unspecified encephalopathy, in adults.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2135,10 +2137,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Occipital-intermittent-rhythmic-delta-activity-morphology</name>
-               <description>Occipital intermittent rhythmic delta activity (OIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 2-3 Hz over the occipital or posterior head regions of one or both sides of the head. Frequently blocked or attenuated by opening the eyes. Comment: most commonly associated with unspecified encephalopathy, in children</description>
+               <description>Occipital intermittent rhythmic delta activity (OIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at 2-3 Hz over the occipital or posterior head regions of one or both sides of the head. Frequently blocked or attenuated by opening the eyes. Comment: most commonly associated with unspecified encephalopathy, in children.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2153,7 +2155,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Temporal intermittent rhythmic delta activity (TIRDA). Fairly regular or approximately sinusoidal waves, mostly occurring in bursts at over the temporal areas of one side of the head. Comment: most commonly associated with temporal lobe epilepsy.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -2165,14 +2167,14 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Periodic-discharges-morphology</name>
-               <description>Periodic discharges not further specified (PDs)</description>
+               <description>Periodic discharges not further specified (PDs).</description>
                <node>
                   <name>Periodic-discharges-superimposed-activity</name>
                   <node>
                      <name>Periodic-discharges-fast-superimposed-activity</name>
                      <node>
                         <name>Periodic-discharges-fast-superimposed-activity-frequency</name>
-                        <description>Hz Values (numbers) typed in.</description>
+                        <description>Value in Hz (number) typed in.</description>
                         <node>
                            <name>#</name>
                            <attribute>
@@ -2190,7 +2192,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      </node>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2204,7 +2206,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Periodic-discharges-rhythmic-superimposed-activity</name>
                      <node>
                         <name>Periodic-discharges-rhythmic-superimposed-activity-frequency</name>
-                        <description>Hz Values (numbers) typed in.</description>
+                        <description>Value in Hz (number) typed in.</description>
                         <node>
                            <name>#</name>
                            <attribute>
@@ -2222,7 +2224,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      </node>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2234,10 +2236,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharges-superimposed-activity-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2254,7 +2256,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Spiky-periodic-discharge-sharpness</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2268,7 +2270,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Sharp-periodic-discharge-sharpness</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2282,7 +2284,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Sharply-contoured-periodic-discharge-sharpness</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2296,7 +2298,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Blunt-periodic-discharge-sharpness</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2308,10 +2310,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-sharpness-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2328,7 +2330,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>1-periodic-discharge-phase</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2342,7 +2344,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>2-periodic-discharge-phases</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2356,7 +2358,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>3-periodic-discharge-phases</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2370,7 +2372,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Greater-than-3-periodic-discharge-phases</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2382,10 +2384,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Number-of-periodic-discharge-phases-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2402,7 +2404,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Periodic-discharge-triphasic-morphology-exists</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2416,7 +2418,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>No-periodic-discharge-triphasic-morphology</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2428,10 +2430,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-triphasic-morphology-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2446,10 +2448,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Periodic-discharge-absolute-amplitude</name>
                   <node>
                      <name>Periodic-discharge-absolute-amplitude-very-low</name>
-                     <description>lower than 20 microV)</description>
+                     <description>Lower than 20 microV.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2461,10 +2463,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Low-periodic-discharge-absolute-amplitude</name>
-                     <description>20 to 49 microV</description>
+                     <description>20 to 49 microV.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2476,10 +2478,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Medium-periodic-discharge-absolute-amplitude</name>
-                     <description>50 to 199 microV</description>
+                     <description>50 to 199 microV.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2491,10 +2493,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>High-periodic-discharge-absolute-amplitude</name>
-                     <description>greater than 200 microV</description>
+                     <description>Greater than 200 microV.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2506,10 +2508,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-absolute-amplitude-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2521,12 +2523,12 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                </node>
                <node>
-                  <name>Periodic-discharge-Relative-amplitude</name>
+                  <name>Periodic-discharge-relative-amplitude</name>
                   <node>
                      <name>Periodic-discharge-relative-amplitude-less-than-equal-2</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2540,7 +2542,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Periodic-discharge-relative-amplitude-greater-than-2</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2552,10 +2554,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-relative-amplitude-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2572,7 +2574,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Positive-periodic-discharge-polarity</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2586,7 +2588,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Negative-periodic-discharge-polarity</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2600,7 +2602,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Unclear-periodic-discharge-polarity</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -2618,7 +2620,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>How the current in the brain reaches the electrode sensors.</description>
             <node>
                <name>Brain-region-source-analysis-laterality</name>
-               <description>Uses Location-property/Laterality tags</description>
+               <description>Uses Location-property/Laterality tags.</description>
             </node>
             <node>
                <name>Brain-region-source-analysis</name>
@@ -2699,7 +2701,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-laterality-left</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2713,7 +2715,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-laterality-left-greater-right</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2727,7 +2729,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-laterality-right</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2741,7 +2743,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-laterality-right-greater-left</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2755,7 +2757,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-laterality-midline</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2769,7 +2771,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-laterality-diffuse-asynchronous</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2786,7 +2788,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-region-frontal</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2800,7 +2802,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-region-temporal</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2814,7 +2816,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-region-central</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2828,7 +2830,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-region-parietal</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2842,7 +2844,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-region-occipital</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2859,7 +2861,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-eyelid</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2873,7 +2875,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-face</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2887,7 +2889,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-arm</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2901,7 +2903,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-leg</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2915,7 +2917,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-trunk</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2929,7 +2931,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-visceral</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2943,7 +2945,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Body-part-hemi</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2960,7 +2962,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-centricity-axial</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2974,7 +2976,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-centricity-proximal-limb</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -2988,7 +2990,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Brain-centricity-distal-limb</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3001,10 +3003,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Sensors</name>
-               <description>lists all corresponding sensors (electrodes/channels in montage)</description>
+               <description>Lists all corresponding sensors (electrodes/channels in montage).</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -3021,7 +3023,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Finding-propagation-observed</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3035,7 +3037,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Finding-propagation-not-observed</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3053,7 +3055,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Multifocal-observed</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3067,7 +3069,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Multifocal-not-observed</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3079,10 +3081,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Multifocal-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3104,7 +3106,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Modulators-reactive</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3118,7 +3120,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Modulators-not-reactive</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3136,7 +3138,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Eye-closure-sensitivity-exists</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3150,7 +3152,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>No-eye-closure-sensitivity</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3163,7 +3165,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Eye-opening-passive</name>
-               <description>Passive eye opening. Used with base schema Increasing/Decreasing</description>
+               <description>Passive eye opening. Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3172,10 +3174,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </attribute>
                <node>
                   <name>Eye-opening-passive-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3188,7 +3190,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Medication-effect-EEG</name>
-               <description>Medications effect on EEG. Used with base schema Increasing/Decreasing</description>
+               <description>Medications effect on EEG. Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3196,10 +3198,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </attribute>
                <node>
                   <name>Medication-effect-EEG-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3212,7 +3214,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Medication-reduction-effect-EEG</name>
-               <description>Medications reduction or withdrawal effect on EEG. Used with base schema Increasing/Decreasing</description>
+               <description>Medications reduction or withdrawal effect on EEG. Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3220,10 +3222,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </attribute>
                <node>
                   <name>Medication-reduction-effect-EEG-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3236,7 +3238,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Auditive-stimuli-effect</name>
-               <description>Used with base schema Increasing/Decreasing</description>
+               <description>Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3244,10 +3246,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </attribute>
                <node>
                   <name>Auditive-stimuli-effect-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3260,7 +3262,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Nociceptive-stimuli-effect</name>
-               <description>Used with base schema Increasing/Decreasing</description>
+               <description>Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3269,10 +3271,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </attribute>
                <node>
                   <name>Nociceptive-stimuli-effect-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3294,7 +3296,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </attribute>
                <node>
                   <name>Physical-effort-effect-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
                      <description>free text</description>
@@ -3309,8 +3311,8 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
             </node>
             <node>
-               <name>Cognitive-tasks-effect</name>
-               <description>Used with base schema Increasing/Decreasing</description>
+               <name>Cognitive-task-effect</name>
+               <description>Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3318,11 +3320,11 @@ This project was supported by the by the National Institute of Mental Health of 
                   <value>Finding-attribute/Finding-triggered-by</value>
                </attribute>
                <node>
-                  <name>Cognitive-tasks-effect-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <name>Cognitive-task-effect-not-possible-to-determine</name>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3337,7 +3339,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Other-modulators-effect-EEG</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -3354,7 +3356,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-alcohol</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3368,7 +3370,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-awake</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3382,7 +3384,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-catamenial</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3396,7 +3398,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-fever</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3410,7 +3412,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-sleep</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3424,7 +3426,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-sleep-deprived</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3438,7 +3440,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Facilitating-factor-other</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3450,13 +3452,13 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
             </node>
             <node>
-               <name>Provocative-factors</name>
+               <name>Provocative-factor</name>
                <description>Provocative factors are defined as transient and sporadic endogenous or exogenous elements capable of evoking/triggering seizures immediately following the exposure to it.</description>
                <node>
                   <name>Hyperventilation-provoked</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3470,7 +3472,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Reflex-provoked</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3483,7 +3485,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Medication-effect-clinical</name>
-               <description>Medications clinical effect. Used with base schema Increasing/Decreasing</description>
+               <description>Medications clinical effect. Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3492,7 +3494,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Medication-reduction-effect-clinical</name>
-               <description>Medications reduction or withdrawal clinical effect. Used with base schema Increasing/Decreasing</description>
+               <description>Medications reduction or withdrawal clinical effect. Used with base schema Increasing/Decreasing.</description>
                <attribute>
                   <name>suggestedTag</name>
                   <value>Finding-attribute/Finding-stopped-by</value>
@@ -3503,7 +3505,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Other-modulators-effect-clinical</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -3519,7 +3521,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Posterior-stimulus-dependent-intermittent-photic-stimulation-response</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3552,7 +3554,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>limited to the stimulus-train</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3584,7 +3586,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Posterior-stimulus-independent-intermittent-photic-stimulation-response-self-sustained</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3614,10 +3616,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Generalized-photoparoxysmal-intermittent-photic-stimulation-response-limited</name>
-                  <description>limited to the stimulus-train</description>
+                  <description>Limited to the stimulus-train.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3649,7 +3651,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Generalized-photoparoxysmal-intermittent-photic-stimulation-response-self-sustained</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3681,7 +3683,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Activation-of-pre-existing-epileptogenic-area-intermittent-photic-stimulation-effect</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3713,7 +3715,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Unmodified-intermittent-photic-stimulation-effect</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3732,7 +3734,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Continuous during non-rapid-eye-movement-sleep (NRS)</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3746,7 +3748,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Modulators-effect-only-during</name>
                   <node>
                      <name>#</name>
-                     <description>Only during Sleep/Awakening/Hyperventilation/Physical effort/Cognitive task. Free text</description>
+                     <description>Only during Sleep/Awakening/Hyperventilation/Physical effort/Cognitive task. Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3758,10 +3760,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Modulators-effect-change-of-patterns</name>
-                  <description>Change of patterns during sleep/awakening</description>
+                  <description>Change of patterns during sleep/awakening.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3778,13 +3780,13 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>Important to estimate how often an interictal abnormality is seen in the recording.</description>
             <node>
                <name>Appearance-mode</name>
-               <description>Describes how the non-ictal EEG pattern/graphoelement is distributed through the recording</description>
+               <description>Describes how the non-ictal EEG pattern/graphoelement is distributed through the recording.</description>
                <node>
                   <name>Random-appearance-mode</name>
-                  <description>Occurrence of the non-ictal EEG pattern / graphoelement without any rhythmicity / periodicity</description>
+                  <description>Occurrence of the non-ictal EEG pattern / graphoelement without any rhythmicity / periodicity.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3799,7 +3801,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Non-ictal EEG pattern / graphoelement occurring at an approximately regular rate / interval (generally of 1 to several seconds).</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3811,10 +3813,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Variable-appearance-mode</name>
-                  <description>Occurrence of non-ictal EEG pattern / graphoelements, that is sometimes rhythmic or periodic, other times random, throughout the recording</description>
+                  <description>Occurrence of non-ictal EEG pattern / graphoelements, that is sometimes rhythmic or periodic, other times random, throughout the recording.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3828,7 +3830,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Intermittent-appearance-mode</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3842,7 +3844,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Continuous-appearance-mode</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3854,10 +3856,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Appearance-mode-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3880,7 +3882,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </attribute>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3899,7 +3901,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </attribute>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3910,7 +3912,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Rhythmic-trains-or-bursts-discharge-pattern-frequency</name>
-                     <description>Hz Values (numbers) typed in.</description>
+                     <description>Value in Hz (number) typed in.</description>
                      <node>
                         <name>#</name>
                         <attribute>
@@ -3936,7 +3938,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </attribute>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3950,7 +3952,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Fragmented-discharge-pattern</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -3963,7 +3965,7 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Finding-extent</name>
-               <description>percentage of occurrence during the recording (background activity and interictal finding)</description>
+               <description>Percentage of occurrence during the recording (background activity and interictal finding).</description>
                <node>
                   <name>#</name>
                   <attribute>
@@ -3977,15 +3979,15 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Periodic-discharge-time-related-features</name>
-               <description>Periodic discharges not further specified (PDs) time-relayed features tags</description>
+               <description>Periodic discharges not further specified (PDs) time-relayed features tags.</description>
                <node>
                   <name>Periodic-discharge-duration</name>
                   <node>
                      <name>Very-brief-periodic-discharge-duration</name>
-                     <description>less than 10 sec</description>
+                     <description>Less than 10 sec.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -3997,10 +3999,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Brief-periodic-discharge-duration</name>
-                     <description>10 to 59 sec</description>
+                     <description>10 to 59 sec.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4012,10 +4014,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Intermediate-periodic-discharge-duration</name>
-                     <description>1 to 4.9 min</description>
+                     <description>1 to 4.9 min.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4027,10 +4029,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Long-periodic-discharge-duration</name>
-                     <description>5 to 59 min</description>
+                     <description>5 to 59 min.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4042,10 +4044,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Very-long-periodic-discharge-duration</name>
-                     <description>greater than 1 hour</description>
+                     <description>Greater than 1 hour.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4057,10 +4059,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-duration-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4077,7 +4079,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Sudden-periodic-discharge-onset</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4091,7 +4093,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Gradual-periodic-discharge-onset</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4103,10 +4105,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-onset-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4123,7 +4125,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Evolving-periodic-discharge-dynamics</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4137,7 +4139,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Fluctuating-periodic-discharge-dynamics</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4151,7 +4153,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Static-periodic-discharge-dynamics</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4163,10 +4165,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Periodic-discharge-dynamics-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -4181,12 +4183,12 @@ This project was supported by the by the National Institute of Mental Health of 
          </node>
          <node>
             <name>Finding-incidence</name>
-            <description>how often it occurs/time-epoch</description>
+            <description>How often it occurs/time-epoch.</description>
             <node>
                <name>Only-once-finding-incidence</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4201,7 +4203,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>less than 1/h</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4213,10 +4215,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Uncommon-finding-incidence</name>
-               <description>1/5 min to 1/h</description>
+               <description>1/5 min to 1/h.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4228,10 +4230,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Occasional-finding-incidence</name>
-               <description>1/min to 1/5min</description>
+               <description>1/min to 1/5min.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4243,10 +4245,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Frequent-finding-incidence</name>
-               <description>1/10 s to 1/min</description>
+               <description>1/10 s to 1/min.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4258,10 +4260,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Abundant-finding-incidence</name>
-               <description>greater than 1/10 s)</description>
+               <description>Greater than 1/10 s).</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4274,13 +4276,13 @@ This project was supported by the by the National Institute of Mental Health of 
          </node>
          <node>
             <name>Finding-prevalence</name>
-            <description>the percentage of the recording covered by the train/burst</description>
+            <description>The percentage of the recording covered by the train/burst.</description>
             <node>
                <name>Rare-finding-prevalence</name>
-               <description>Less than 1 precents</description>
+               <description>Less than 1 precent.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4292,10 +4294,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Occasional-finding-prevalence</name>
-               <description>1 to 9 percents</description>
+               <description>1 to 9 percent.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4307,10 +4309,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Frequent-finding-prevalence</name>
-               <description>10 to 49 precents</description>
+               <description>10 to 49 precent.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4322,10 +4324,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Abundant-finding-prevalence</name>
-               <description>50 to 89 percents</description>
+               <description>50 to 89 percent.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4337,10 +4339,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Continuous-finding-prevalence</name>
-               <description>Greater than 90 precents</description>
+               <description>Greater than 90 precent.</description>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -4356,7 +4358,7 @@ This project was supported by the by the National Institute of Mental Health of 
             <description>Posterior dominant rhythm is the most often scored EEG feature in clinical practice. Therefore, there are specific terms that can be chosen for characterizing the PDR.</description>
             <node>
                <name>Posterior-dominant-rhythm-frequency</name>
-               <description>Hz Values (numbers) typed in.</description>
+               <description>Value in Hz (number) typed in.</description>
                <node>
                   <name>#</name>
                   <attribute>
@@ -4376,10 +4378,10 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Posterior-dominant-rhythm-amplitude-range</name>
                <node>
                   <name>Low-posterior-dominant-rhythm-amplitude-range</name>
-                  <description>Low (less than 20 microV)</description>
+                  <description>Low (less than 20 microV).</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4391,10 +4393,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Medium-posterior-dominant-rhythm-amplitude-range</name>
-                  <description>Medium (between 20 and 70 microV)</description>
+                  <description>Medium (between 20 and 70 microV).</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4406,10 +4408,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>High-posterior-dominant-rhythm-amplitude-range</name>
-                  <description>High (more than 70 microV)</description>
+                  <description>High (more than 70 microV).</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4421,10 +4423,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-amplitude-range-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4437,13 +4439,13 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Posterior-dominant-rhythm-amplitude-asymmetry</name>
-               <description>A difference in amplitude between the homologous area on opposite sides of the head that consistently exceeds 50 percent. When symmetrical could be labeled with base schema Symmetrical tag</description>
+               <description>A difference in amplitude between the homologous area on opposite sides of the head that consistently exceeds 50 percent. When symmetrical could be labeled with base schema Symmetrical tag.</description>
                <node>
                   <name>Posterior-dominant-rhythm-amplitude-asymmetry-lower-left</name>
                   <description>Amplitude lower on the left side.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4458,7 +4460,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Amplitude lower on the right side.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4470,10 +4472,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-amplitude-asymmetry-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4486,13 +4488,13 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Posterior-dominant-rhythm-frequency-asymmetry</name>
-               <description>When symmetrical could be labeled with base schema Symmetrical tag</description>
+               <description>When symmetrical could be labeled with base schema Symmetrical tag.</description>
                <node>
                   <name>Posterior-dominant-rhythm-frequency-asymmetry-lower-left</name>
                   <description>Hz lower on the left side.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4507,7 +4509,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Hz lower on the right side.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4523,10 +4525,10 @@ This project was supported by the by the National Institute of Mental Health of 
                <description>Change (disappearance or measurable decrease in amplitude) of a posterior dominant rhythm following eye-opening. Eye closure has the opposite effect.</description>
                <node>
                   <name>Posterior-dominant-rhythm-eye-opening-reactivity-exists</name>
-                  <description>When annotated Yes</description>
+                  <description>When annotated Yes.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4538,10 +4540,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-eye-opening-reactivity-reduced-left</name>
-                  <description>Reduced left side reactivity</description>
+                  <description>Reduced left side reactivity.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4553,7 +4555,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-eye-opening-reactivity-reduced-rigth</name>
-                  <description>Reduced right side reactivity</description>
+                  <description>Reduced right side reactivity.</description>
                   <node>
                      <name>#</name>
                      <description>free text</description>
@@ -4568,10 +4570,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-eye-opening-reactivity-reduced-both</name>
-                  <description>Reduced reactivity on both sides</description>
+                  <description>Reduced reactivity on both sides.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4583,10 +4585,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-eye-opening-reactivity-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4599,13 +4601,13 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Posterior-dominant-rhythm-organization</name>
-               <description>When normal could be labeled with base schema Normal tag</description>
+               <description>When normal could be labeled with base schema Normal tag.</description>
                <node>
                   <name>Posterior-dominant-rhythm-organization-poorly-organized</name>
-                  <description>Poorly organized</description>
+                  <description>Poorly organized.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4617,10 +4619,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-organization-disorganized</name>
-                  <description>Disorganized</description>
+                  <description>Disorganized.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4632,10 +4634,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Posterior-dominant-rhythm-organization-markedly-disorganized</name>
-                  <description>Markedly disorganized</description>
+                  <description>Markedly disorganized.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4648,12 +4650,12 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Posterior-dominant-rhythm-caveat</name>
-               <description>Caveats to the annotation of PDR</description>
+               <description>Caveat to the annotation of PDR.</description>
                <node>
                   <name>No-posterior-dominant-rhythm-caveat</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4667,7 +4669,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Posterior-dominant-rhythm-caveat-only-open-eyes-during-the-recording</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4681,7 +4683,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Posterior-dominant-rhythm-caveat-sleep-deprived-caveat</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4695,7 +4697,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Posterior-dominant-rhythm-caveat-drowsy</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4711,12 +4713,12 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Absence-of-posterior-dominant-rhythm</name>
-               <description>Reason for absence of PDR</description>
+               <description>Reason for absence of PDR.</description>
                <node>
                   <name>Absence-of-posterior-dominant-rhythm-artifacts</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4730,7 +4732,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Absence-of-posterior-dominant-rhythm-extreme-low-voltage</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4744,7 +4746,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Absence-of-posterior-dominant-rhythm-eye-closure-could-not-be-achieved</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4758,7 +4760,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Absence-of-posterior-dominant-rhythm-lack-of-awake-period</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4772,7 +4774,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Absence-of-posterior-dominant-rhythm-lack-of-compliance</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4786,7 +4788,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Absence-of-posterior-dominant-rhythm-other-causes</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4802,12 +4804,12 @@ This project was supported by the by the National Institute of Mental Health of 
             <name>Sleep-property</name>
             <node>
                <name>Sleep-abnormal-amplitude-asymmetry</name>
-               <description>Absence or consistently marked amplitude asymmetry (greater than 50 precent) of a normal sleep graphoelement</description>
+               <description>Absence or consistently marked amplitude asymmetry (greater than 50 precent) of a normal sleep graphoelement.</description>
                <node>
                   <name>Sleep-abnormal-amplitude-asymmetry-exists</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4822,7 +4824,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Amplitude lower on the left side.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4837,7 +4839,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <description>Amplitude lower on the right side.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -4958,23 +4960,23 @@ This project was supported by the by the National Institute of Mental Health of 
                      </node>
                      <node>
                         <name>Semiology-motor-postural</name>
-                        <description>Adoption of a posture that may be bilaterally symmetric or asymmetric (as in a fencing posture)</description>
+                        <description>Adoption of a posture that may be bilaterally symmetric or asymmetric (as in a fencing posture).</description>
                      </node>
                      <node>
                         <name>Semiology-motor-versive</name>
-                        <description>A sustained, forced conjugate ocular, cephalic, and/or truncal rotation or lateral deviation from the midline</description>
+                        <description>A sustained, forced conjugate ocular, cephalic, and/or truncal rotation or lateral deviation from the midline.</description>
                      </node>
                      <node>
                         <name>Semiology-motor-clonic</name>
-                        <description>Myoclonus that is regularly repetitive, involves the same muscle groups, at a frequency of about 2 to 3 c/s, and is prolonged. Synonym: rhythmic myoclonus</description>
+                        <description>Myoclonus that is regularly repetitive, involves the same muscle groups, at a frequency of about 2 to 3 c/s, and is prolonged. Synonym: rhythmic myoclonus .</description>
                      </node>
                      <node>
                         <name>Semiology-motor-myoclonic</name>
-                        <description>Characterized by myoclonus. MYOCLONUS : sudden, brief (lower than 100 ms) involuntary single or multiple contraction(s) of muscles(s) or muscle groups of variable topography (axial, proximal limb, distal)</description>
+                        <description>Characterized by myoclonus. MYOCLONUS : sudden, brief (lower than 100 ms) involuntary single or multiple contraction(s) of muscles(s) or muscle groups of variable topography (axial, proximal limb, distal).</description>
                      </node>
                      <node>
                         <name>Semiology-motor-jacksonian-march</name>
-                        <description>Term indicating spread of clonic movements through contiguous body parts unilaterally</description>
+                        <description>Term indicating spread of clonic movements through contiguous body parts unilaterally.</description>
                      </node>
                      <node>
                         <name>Semiology-motor-negative-myoclonus</name>
@@ -5008,7 +5010,7 @@ This project was supported by the by the National Institute of Mental Health of 
                         <name>Semiology-motor-other-elementary-motor</name>
                         <node>
                            <name>#</name>
-                           <description>free text</description>
+                           <description>Free text.</description>
                            <attribute>
                               <name>takesValue</name>
                            </attribute>
@@ -5035,7 +5037,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      </node>
                      <node>
                         <name>Semiology-motor-automatisms-dyspraxic</name>
-                        <description>Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation</description>
+                        <description>Inability to perform learned movements spontaneously or on command or imitation despite intact relevant motor and sensory systems and adequate comprehension and cooperation.</description>
                      </node>
                      <node>
                         <name>Semiology-motor-automatisms-manual</name>
@@ -5065,7 +5067,7 @@ This project was supported by the by the National Institute of Mental Health of 
                         <name>Semiology-motor-other-automatisms</name>
                         <node>
                            <name>#</name>
-                           <description>free text</description>
+                           <description>Free text.</description>
                            <attribute>
                               <name>takesValue</name>
                            </attribute>
@@ -5078,7 +5080,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Semiology-motor-behavioral-arrest</name>
-                     <description>Interruption of ongoing motor activity or of ongoing behaviors with fixed gaze, without movement of the head or trunk (oro-alimentary and hand automatisms may continue)</description>
+                     <description>Interruption of ongoing motor activity or of ongoing behaviors with fixed gaze, without movement of the head or trunk (oro-alimentary and hand automatisms may continue).</description>
                   </node>
                </node>
                <node>
@@ -5087,7 +5089,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Semiology-sensory</name>
                      <node>
                         <name>Semiology-sensory-headache</name>
-                        <description>Headache occurring in close temporal proximity to the seizure or as the sole seizure manifestation</description>
+                        <description>Headache occurring in close temporal proximity to the seizure or as the sole seizure manifestation.</description>
                      </node>
                      <node>
                         <name>Semiology-sensory-visual</name>
@@ -5114,7 +5116,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      </node>
                      <node>
                         <name>Semiology-sensory-painful</name>
-                        <description>Peripheral (lateralized/bilateral), cephalic, abdominal</description>
+                        <description>Peripheral (lateralized/bilateral), cephalic, abdominal.</description>
                      </node>
                      <node>
                         <name>Semiology-sensory-autonomic-sensation</name>
@@ -5124,7 +5126,7 @@ This project was supported by the by the National Institute of Mental Health of 
                         <name>Semiology-sensory-other</name>
                         <node>
                            <name>#</name>
-                           <description>free text</description>
+                           <description>Free text.</description>
                            <attribute>
                               <name>takesValue</name>
                            </attribute>
@@ -5163,7 +5165,7 @@ This project was supported by the by the National Institute of Mental Health of 
                         <name>Semiology-experiential-other</name>
                         <node>
                            <name>#</name>
-                           <description>free text</description>
+                           <description>Free text.</description>
                            <attribute>
                               <name>takesValue</name>
                            </attribute>
@@ -5176,7 +5178,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Semiology-dyscognitive</name>
-                     <description>The term describes events in which (1) disturbance of cognition is the predominant or most apparent feature, and (2a) two or more of the following components are involved, or (2b) involvement of such components remains undetermined. Otherwise, use the more specific term (e.g., mnemonic experiential seizure  or hallucinatory experiential seizure). Components of cognition: ++ perception: symbolic conception of sensory information ++ attention: appropriate selection of a principal perception or task ++ emotion: appropriate affective significance of a perception ++ memory: ability to store and retrieve percepts or concepts ++ executive function: anticipation, selection, monitoring of consequences, and initiation of motor activity including praxis, speech</description>
+                     <description>The term describes events in which (1) disturbance of cognition is the predominant or most apparent feature, and (2a) two or more of the following components are involved, or (2b) involvement of such components remains undetermined. Otherwise, use the more specific term (e.g., mnemonic experiential seizure  or hallucinatory experiential seizure). Components of cognition: ++ perception: symbolic conception of sensory information ++ attention: appropriate selection of a principal perception or task ++ emotion: appropriate affective significance of a perception ++ memory: ability to store and retrieve percepts or concepts ++ executive function: anticipation, selection, monitoring of consequences, and initiation of motor activity including praxis, speech.</description>
                   </node>
                   <node>
                      <name>Semiology-language-related</name>
@@ -5196,7 +5198,7 @@ This project was supported by the by the National Institute of Mental Health of 
                         <name>Semiology-language-related-other</name>
                         <node>
                            <name>#</name>
-                           <description>free text</description>
+                           <description>Free text.</description>
                            <attribute>
                               <name>takesValue</name>
                            </attribute>
@@ -5211,7 +5213,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Semiology-autonomic</name>
                      <node>
                         <name>Semiology-autonomic-pupillary</name>
-                        <description>Mydriasis, miosis (either bilateral or unilateral)</description>
+                        <description>Mydriasis, miosis (either bilateral or unilateral).</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-hypersalivation</name>
@@ -5219,41 +5221,41 @@ This project was supported by the by the National Institute of Mental Health of 
                      </node>
                      <node>
                         <name>Semiology-autonomic-respiratory-apnoeic</name>
-                        <description>subjective shortness of breath, hyperventilation, stridor, coughing, choking, apnea, oxygen desaturation, neurogenic pulmonary edema</description>
+                        <description>subjective shortness of breath, hyperventilation, stridor, coughing, choking, apnea, oxygen desaturation, neurogenic pulmonary edema.</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-cardiovascular</name>
-                        <description>Modifications of heart rate (tachycardia, bradycardia), cardiac arrhythmias (such as sinus arrhythmia, sinus arrest, supraventricular tachycardia, atrial premature depolarizations, ventricular premature depolarizations, atrio-ventricular block, bundle branch block, atrioventricular nodal escape rhythm, asystole)</description>
+                        <description>Modifications of heart rate (tachycardia, bradycardia), cardiac arrhythmias (such as sinus arrhythmia, sinus arrest, supraventricular tachycardia, atrial premature depolarizations, ventricular premature depolarizations, atrio-ventricular block, bundle branch block, atrioventricular nodal escape rhythm, asystole).</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-gastrointestinal</name>
-                        <description>Nausea, eructation, vomiting, retching, abdominal sensations, abdominal pain, flatulence, spitting, diarrhea</description>
+                        <description>Nausea, eructation, vomiting, retching, abdominal sensations, abdominal pain, flatulence, spitting, diarrhea.</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-urinary-incontinence</name>
-                        <description>urinary urge (intense urinary urge at the beginning of seizures), urinary incontinence, ictal urination (rare symptom of partial seizures without loss of consciousness)</description>
+                        <description>urinary urge (intense urinary urge at the beginning of seizures), urinary incontinence, ictal urination (rare symptom of partial seizures without loss of consciousness).</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-genital</name>
-                        <description>Sexual auras (erotic thoughts and feelings, sexual arousal and orgasm). Genital auras (unpleasant, sometimes painful, frightening or emotionally neutral somatosensory sensations in the genitals that can be accompanied by ictal orgasm). Sexual automatisms (hypermotor movements consisting of writhing, thrusting, rhythmic movements of the pelvis, arms and legs, sometimes associated with picking and rhythmic manipulation of the groin or genitalia, exhibitionism and masturbation)</description>
+                        <description>Sexual auras (erotic thoughts and feelings, sexual arousal and orgasm). Genital auras (unpleasant, sometimes painful, frightening or emotionally neutral somatosensory sensations in the genitals that can be accompanied by ictal orgasm). Sexual automatisms (hypermotor movements consisting of writhing, thrusting, rhythmic movements of the pelvis, arms and legs, sometimes associated with picking and rhythmic manipulation of the groin or genitalia, exhibitionism and masturbation).</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-vasomotor</name>
-                        <description>Flushing or pallor (may be accompanied by feelings of warmth, cold and pain)</description>
+                        <description>Flushing or pallor (may be accompanied by feelings of warmth, cold and pain).</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-sudomotor</name>
-                        <description>Sweating and piloerection ( may be accompanied by feelings of warmth, cold and pain)</description>
+                        <description>Sweating and piloerection (may be accompanied by feelings of warmth, cold and pain).</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-thermoregulatory</name>
-                        <description>Hyperthermia, fever</description>
+                        <description>Hyperthermia, fever.</description>
                      </node>
                      <node>
                         <name>Semiology-autonomic-other</name>
                         <node>
                            <name>#</name>
-                           <description>free text</description>
+                           <description>Free text.</description>
                            <attribute>
                               <name>takesValue</name>
                            </attribute>
@@ -5269,7 +5271,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Semiology-manifestation-other</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -5303,11 +5305,11 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Postictal-semiology-impaired-cognition</name>
-                  <description>Decreased Cognitive performance involving one or more of perception, attention, emotion, memory, execution, praxis, speech</description>
+                  <description>Decreased Cognitive performance involving one or more of perception, attention, emotion, memory, execution, praxis, speech.</description>
                </node>
                <node>
                   <name>Postictal-semiology-dysphoria</name>
-                  <description>Depression, irritability, euphoric mood, fear, anxiety</description>
+                  <description>Depression, irritability, euphoric mood, fear, anxiety.</description>
                </node>
                <node>
                   <name>Postictal-semiology-headache</name>
@@ -5319,11 +5321,11 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Postictal-semiology-anterograde-amnesia</name>
-                  <description>Impaired ability to remember new material</description>
+                  <description>Impaired ability to remember new material.</description>
                </node>
                <node>
                   <name>Postictal-semiology-retrograde-amnesia</name>
-                  <description>Impaired ability to recall previously remember material</description>
+                  <description>Impaired ability to recall previously remember material.</description>
                </node>
                <node>
                   <name>Postictal-semiology-paresis</name>
@@ -5341,7 +5343,7 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Postictal-semiology-other-unilateral-motor-phenomena</name>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -5362,10 +5364,10 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Polygraphic-channel-relation-to-episode-not-possible-to-determine</name>
-                  <description>Not possible to determine</description>
+                  <description>Not possible to determine.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
+                     <description>Free text.</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
@@ -5390,14 +5392,14 @@ This project was supported by the by the National Institute of Mental Health of 
             </node>
             <node>
                <name>Episode-time-context-property</name>
-               <description>Additional clinically relevant features related to episodes can be scored under timing and context. If needed, episode duration can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Temporal-value/Duration</description>
+               <description>Additional clinically relevant features related to episodes can be scored under timing and context. If needed, episode duration can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Temporal-value/Duration.</description>
                <node>
                   <name>Episode-consciousness</name>
                   <node>
                      <name>Episode-consciousness-not-tested</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5411,7 +5413,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-consciousness-affected</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5425,7 +5427,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-consciousness-mildly-affected</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5439,7 +5441,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-consciousness-not-affected</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5451,10 +5453,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Episode-consciousness-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5471,7 +5473,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-awareness-exists</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5485,7 +5487,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>No-episode-awareness</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5497,10 +5499,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Episode-awareness-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5515,31 +5517,37 @@ This project was supported by the by the National Institute of Mental Health of 
                   <name>Clinical-EEG-temporal-relationship</name>
                   <node>
                      <name>Clinical-start-followed-EEG</name>
-                     <description>Clinical start, followed by EEG start by X seconds</description>
+                     <description>Clinical start, followed by EEG start by X seconds.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
                         <attribute>
                            <name>valueClass</name>
-                           <value>textClass</value>
+                           <value>numericClass</value>
+                        </attribute>
+                        <attribute>
+                           <name>unitClass</name>
+                           <value>timeUnits</value>
                         </attribute>
                      </node>
                   </node>
                   <node>
                      <name>EEG-start-followed-clinical</name>
-                     <description>EEG start, followed by clinical start by X seconds</description>
+                     <description>EEG start, followed by clinical start by X seconds.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
                         <attribute>
                            <name>valueClass</name>
-                           <value>textClass</value>
+                           <value>numericClass</value>
+                        </attribute>
+                        <attribute>
+                           <name>unitClass</name>
+                           <value>timeUnits</value>
                         </attribute>
                      </node>
                   </node>
@@ -5548,10 +5556,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Clinical-EEG-temporal-relationship-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5564,24 +5572,23 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Episode-event-count</name>
-                  <description>Number of stereotypical episodes during the recording</description>
+                  <description>Number of stereotypical episodes during the recording.</description>
                   <node>
                      <name>#</name>
-                     <description>free text</description>
                      <attribute>
                         <name>takesValue</name>
                      </attribute>
                      <attribute>
                         <name>valueClass</name>
-                        <value>textClass</value>
+                        <value>numericClass</value>
                      </attribute>
                   </node>
                   <node>
                      <name>Episode-event-count-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5594,12 +5601,12 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>State-episode-start</name>
-                  <description>State at the start of the episode</description>
+                  <description>State at the start of the episode.</description>
                   <node>
                      <name>Episode-start-from-sleep</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5613,7 +5620,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-start-from-awake</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5625,10 +5632,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>State-episode-start-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5657,10 +5664,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Episode-postictal-phase-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5678,7 +5685,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-prodrome-exists</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5692,7 +5699,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>No-episode-prodrome</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5709,7 +5716,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Episode-tongue-biting-exists</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5723,7 +5730,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>No-episode-tongue-biting</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5736,12 +5743,12 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Seizure-dynamics</name>
-                  <description>Spatiotemporal dynamics can be scored (evolution in morphology; evolution in frequency; evolution in location)</description>
+                  <description>Spatiotemporal dynamics can be scored (evolution in morphology; evolution in frequency; evolution in location).</description>
                   <node>
                      <name>Seizure-dynamics-evolution-morphology</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5755,7 +5762,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Seizure-dynamics-evolution-frequency</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5769,7 +5776,7 @@ This project was supported by the by the National Institute of Mental Health of 
                      <name>Seizure-dynamics-evolution-location</name>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5781,10 +5788,10 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>Seizure-dynamics-not-possible-to-determine</name>
-                     <description>Not possible to determine</description>
+                     <description>Not possible to determine.</description>
                      <node>
                         <name>#</name>
-                        <description>free text</description>
+                        <description>Free text.</description>
                         <attribute>
                            <name>takesValue</name>
                         </attribute>
@@ -5804,7 +5811,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Recording-not-interpretable-due-to-artifact</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -5818,7 +5825,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Recording-of-reduced-diagnostic-value-due-to-artifact</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -5832,7 +5839,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>Artifact-does-not-interfere-recording</name>
                <node>
                   <name>#</name>
-                  <description>free text</description>
+                  <description>Free text.</description>
                   <attribute>
                      <name>takesValue</name>
                   </attribute>
@@ -5860,6 +5867,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -5873,6 +5884,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>SIUnit</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>rad</name>
@@ -5882,9 +5897,17 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>degree</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.0174533</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -5901,6 +5924,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -5912,6 +5939,10 @@ This project was supported by the by the National Institute of Mental Health of 
          </attribute>
          <unit>
             <name>dollar</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>$</name>
@@ -5921,9 +5952,46 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
+         </unit>
+         <unit>
+            <name>euro</name>
          </unit>
          <unit>
             <name>point</name>
+         </unit>
+      </unitClassDefinition>
+      <unitClassDefinition>
+         <name>electricPotentialUnits</name>
+         <attribute>
+            <name>defaultUnits</name>
+            <value>uv</value>
+         </attribute>
+         <unit>
+            <name>v</name>
+            <attribute>
+               <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.000001</value>
+            </attribute>
+         </unit>
+         <unit>
+            <name>Volt</name>
+            <attribute>
+               <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.000001</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -5937,6 +6005,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>SIUnit</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>Hz</name>
@@ -5946,16 +6018,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
-         </unit>
-      </unitClassDefinition>
-      <unitClassDefinition>
-         <name>amplitudeUnits</name>
-         <attribute>
-            <name>defaultUnits</name>
-            <value>microvolts</value>
-         </attribute>
-         <unit>
-            <name>microvolts</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -5966,9 +6032,13 @@ This project was supported by the by the National Institute of Mental Health of 
          </attribute>
          <unit>
             <name>dB</name>
-            <description>Intensity expressed as ratio to a threshold. Often used for sound intensity.</description>
+            <description>Intensity expressed as ratio to a threshold. May be used for sound intensity.</description>
             <attribute>
                <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
             </attribute>
          </unit>
          <unit>
@@ -6000,6 +6070,41 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
+         </unit>
+      </unitClassDefinition>
+      <unitClassDefinition>
+         <name>magneticFieldUnits</name>
+         <description>Units used to magnetic field intensity.</description>
+         <attribute>
+            <name>defaultUnits</name>
+            <value>fT</value>
+         </attribute>
+         <unit>
+            <name>tesla</name>
+            <attribute>
+               <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>10^-15</value>
+            </attribute>
+         </unit>
+         <unit>
+            <name>T</name>
+            <attribute>
+               <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>10^-15</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -6013,6 +6118,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>SIUnit</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>B</name>
@@ -6021,6 +6130,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </attribute>
             <attribute>
                <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
             </attribute>
          </unit>
       </unitClassDefinition>
@@ -6032,14 +6145,26 @@ This project was supported by the by the National Institute of Mental Health of 
          </attribute>
          <unit>
             <name>foot</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.3048</value>
+            </attribute>
          </unit>
          <unit>
             <name>inch</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.0254</value>
+            </attribute>
          </unit>
          <unit>
             <name>metre</name>
             <attribute>
                <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
             </attribute>
          </unit>
          <unit>
@@ -6050,9 +6175,17 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>mile</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1609.34</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -6069,17 +6202,55 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>mph</name>
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.44704</value>
+            </attribute>
          </unit>
          <unit>
             <name>kph</name>
             <attribute>
                <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>0.277778</value>
+            </attribute>
+         </unit>
+      </unitClassDefinition>
+      <unitClassDefinition>
+         <name>temperatureUnits</name>
+         <unit>
+            <name>degree Celsius</name>
+            <attribute>
+               <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
+         </unit>
+         <unit>
+            <name>oC</name>
+            <attribute>
+               <name>SIUnit</name>
+            </attribute>
+            <attribute>
+               <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
             </attribute>
          </unit>
       </unitClassDefinition>
@@ -6094,6 +6265,10 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>SIUnit</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>s</name>
@@ -6103,16 +6278,32 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>day</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>86400</value>
+            </attribute>
          </unit>
          <unit>
             <name>minute</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>60</value>
+            </attribute>
          </unit>
          <unit>
             <name>hour</name>
             <description>Should be in 24-hour format.</description>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>3600</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
       <unitClassDefinition>
@@ -6128,6 +6319,10 @@ This project was supported by the by the National Institute of Mental Health of 
             </attribute>
             <attribute>
                <name>unitSymbol</name>
+            </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
             </attribute>
          </unit>
       </unitClassDefinition>
@@ -6145,18 +6340,34 @@ This project was supported by the by the National Institute of Mental Health of 
             <attribute>
                <name>unitSymbol</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>gram</name>
             <attribute>
                <name>SIUnit</name>
             </attribute>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>1.0</value>
+            </attribute>
          </unit>
          <unit>
             <name>pound</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>453.592</value>
+            </attribute>
          </unit>
          <unit>
             <name>lb</name>
+            <attribute>
+               <name>conversionFactor</name>
+               <value>453.592</value>
+            </attribute>
          </unit>
       </unitClassDefinition>
    </unitClassDefinitions>
@@ -6167,12 +6378,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10.0</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>da</name>
          <description>SI unit multiple representing 10^1</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10.0</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6181,12 +6400,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>100.0</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>h</name>
          <description>SI unit multiple representing 10^2</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>100.0</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6195,12 +6422,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>1000.0</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>k</name>
          <description>SI unit multiple representing 10^3</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>1000.0</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6209,12 +6444,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^6</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>M</name>
          <description>SI unit multiple representing 10^6</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^6</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6223,12 +6466,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^9</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>G</name>
          <description>SI unit multiple representing 10^9</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^9</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6237,12 +6488,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^12</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>T</name>
          <description>SI unit multiple representing 10^12</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^12</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6251,12 +6510,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^15</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>P</name>
          <description>SI unit multiple representing 10^15</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^15</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6265,12 +6532,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^18</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>E</name>
          <description>SI unit multiple representing 10^18</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^18</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6279,12 +6554,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^21</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>Z</name>
          <description>SI unit multiple representing 10^21</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^21</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6293,12 +6576,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^24</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>Y</name>
          <description>SI unit multiple representing 10^24</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^24</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6307,12 +6598,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>0.1</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>d</name>
          <description>SI unit submultiple representing 10^-1</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>0.1</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6321,12 +6620,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>0.01</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>c</name>
          <description>SI unit submultiple representing 10^-2</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>0.01</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6335,12 +6642,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>0.001</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>m</name>
          <description>SI unit submultiple representing 10^-3</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>0.001</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6349,12 +6664,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-6</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>u</name>
          <description>SI unit submultiple representing 10^-6</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-6</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6363,12 +6686,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-9</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>n</name>
          <description>SI unit submultiple representing 10^-9</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-9</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6377,12 +6708,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-12</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>p</name>
          <description>SI unit submultiple representing 10^-12</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-12</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6391,12 +6730,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-15</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>f</name>
          <description>SI unit submultiple representing 10^-15</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-15</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6405,12 +6752,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-18</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>a</name>
          <description>SI unit submultiple representing 10^-18</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-18</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6419,12 +6774,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-21</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>z</name>
          <description>SI unit submultiple representing 10^-21</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-21</value>
          </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
@@ -6433,12 +6796,20 @@ This project was supported by the by the National Institute of Mental Health of 
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-24</value>
+         </attribute>
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>y</name>
          <description>SI unit submultiple representing 10^-24</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
+         </attribute>
+         <attribute>
+            <name>conversionFactor</name>
+            <value>10^-24</value>
          </attribute>
       </unitModifierDefinition>
    </unitModifierDefinitions>
@@ -6519,6 +6890,16 @@ This project was supported by the by the National Institute of Mental Health of 
          <description>A schema attribute of value classes specifying a special character that is allowed in expressing the value of a placeholder. Normally the allowed characters are listed individually. However, the word letters designates the upper and lower case alphabetic characters and the word digits designates the digits 0-9. The word blank designates the blank character.</description>
          <property>
             <name>valueClassProperty</name>
+         </property>
+      </schemaAttributeDefinition>
+      <schemaAttributeDefinition>
+         <name>conversionFactor</name>
+         <description>The multiplicative factor to multiply these units to convert to default units.</description>
+         <property>
+            <name>unitProperty</name>
+         </property>
+         <property>
+            <name>unitModifierProperty</name>
          </property>
       </schemaAttributeDefinition>
       <schemaAttributeDefinition>
@@ -6610,7 +6991,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </schemaAttributeDefinition>
       <schemaAttributeDefinition>
          <name>topLevelTagGroup</name>
-         <description>A schema attribute indicating that this tag (or its descendants) can only appear in a top-level tag group.</description>
+         <description>A schema attribute indicating that this tag (or its descendants) can only appear in a top-level tag group. A tag group can have at most one tag with this attribute.</description>
          <property>
             <name>boolProperty</name>
          </property>

--- a/library_schemas/score/prerelease/HED_score_1.0.0.xml
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.xml
@@ -527,24 +527,24 @@ This project was supported by the by the National Institute of Mental Health of 
          <node>
             <name>Interictal-special-patterns</name>
             <node>
-               <name>Interictal-periodic-discharge</name>
-               <description>Periodic discharge not further specified (PD).</description>
+               <name>Interictal-periodic-discharges</name>
+               <description>Periodic discharge not further specified (PDs).</description>
             </node>
             <node>
-               <name>Generalized-periodic-discharge</name>
-               <description>GPD.</description>
+               <name>Generalized-periodic-discharges</name>
+               <description>GPDs.</description>
             </node>
             <node>
-               <name>Lateralized-periodic-discharge</name>
-               <description>LPD.</description>
+               <name>Lateralized-periodic-discharges</name>
+               <description>LPDs.</description>
             </node>
             <node>
-               <name>Bilateral-independent-periodic-discharge</name>
-               <description>BIPD.</description>
+               <name>Bilateral-independent-periodic-discharges</name>
+               <description>BIPDs.</description>
             </node>
             <node>
-               <name>Multifocal-periodic-discharge</name>
-               <description>MfPD.</description>
+               <name>Multifocal-periodic-discharges</name>
+               <description>MfPDs.</description>
             </node>
             <node>
                <name>Interictal-extreme-delta-brush</name>
@@ -589,7 +589,7 @@ This project was supported by the by the National Institute of Mental Health of 
          </node>
          <node>
             <name>Subtle-seizure</name>
-            <description>Seizure type frequent in neonates, sometimes referred to as motor automatism; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges, and are clearly epileptic, ictal EEG often does not show typical epileptic activity.</description>
+            <description>Seizure type frequent in neonates, sometimes referred to as motor automatisms; they may include random and roving eye movements, sucking, chewing motions, tongue protrusion, rowing or swimming or boxing movements of the arms, pedaling and bicycling movements of the lower limbs; apneic seizures are relatively common. Although some subtle seizures are associated with rhythmic ictal EEG discharges, and are clearly epileptic, ictal EEG often does not show typical epileptic activity.</description>
          </node>
          <node>
             <name>Electrographic-seizure</name>
@@ -6374,7 +6374,7 @@ This project was supported by the by the National Institute of Mental Health of 
    <unitModifierDefinitions>
       <unitModifierDefinition>
          <name>deca</name>
-         <description>SI unit multiple representing 10^1</description>
+         <description>SI unit multiple representing 10^1.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6385,7 +6385,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>da</name>
-         <description>SI unit multiple representing 10^1</description>
+         <description>SI unit multiple representing 10^1.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6396,7 +6396,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>hecto</name>
-         <description>SI unit multiple representing 10^2</description>
+         <description>SI unit multiple representing 10^2.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6407,7 +6407,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>h</name>
-         <description>SI unit multiple representing 10^2</description>
+         <description>SI unit multiple representing 10^2.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6418,7 +6418,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>kilo</name>
-         <description>SI unit multiple representing 10^3</description>
+         <description>SI unit multiple representing 10^3.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6429,7 +6429,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>k</name>
-         <description>SI unit multiple representing 10^3</description>
+         <description>SI unit multiple representing 10^3.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6440,7 +6440,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>mega</name>
-         <description>SI unit multiple representing 10^6</description>
+         <description>SI unit multiple representing 10^6.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6451,7 +6451,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>M</name>
-         <description>SI unit multiple representing 10^6</description>
+         <description>SI unit multiple representing 10^6.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6462,7 +6462,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>giga</name>
-         <description>SI unit multiple representing 10^9</description>
+         <description>SI unit multiple representing 10^9.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6473,7 +6473,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>G</name>
-         <description>SI unit multiple representing 10^9</description>
+         <description>SI unit multiple representing 10^9.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6484,7 +6484,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>tera</name>
-         <description>SI unit multiple representing 10^12</description>
+         <description>SI unit multiple representing 10^12.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6495,7 +6495,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>T</name>
-         <description>SI unit multiple representing 10^12</description>
+         <description>SI unit multiple representing 10^12.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6506,7 +6506,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>peta</name>
-         <description>SI unit multiple representing 10^15</description>
+         <description>SI unit multiple representing 10^15.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6517,7 +6517,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>P</name>
-         <description>SI unit multiple representing 10^15</description>
+         <description>SI unit multiple representing 10^15.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6528,7 +6528,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>exa</name>
-         <description>SI unit multiple representing 10^18</description>
+         <description>SI unit multiple representing 10^18.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6539,7 +6539,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>E</name>
-         <description>SI unit multiple representing 10^18</description>
+         <description>SI unit multiple representing 10^18.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6550,7 +6550,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>zetta</name>
-         <description>SI unit multiple representing 10^21</description>
+         <description>SI unit multiple representing 10^21.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6561,7 +6561,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>Z</name>
-         <description>SI unit multiple representing 10^21</description>
+         <description>SI unit multiple representing 10^21.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6572,7 +6572,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>yotta</name>
-         <description>SI unit multiple representing 10^24</description>
+         <description>SI unit multiple representing 10^24.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6583,7 +6583,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>Y</name>
-         <description>SI unit multiple representing 10^24</description>
+         <description>SI unit multiple representing 10^24.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6594,7 +6594,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>deci</name>
-         <description>SI unit submultiple representing 10^-1</description>
+         <description>SI unit submultiple representing 10^-1.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6605,7 +6605,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>d</name>
-         <description>SI unit submultiple representing 10^-1</description>
+         <description>SI unit submultiple representing 10^-1.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6616,7 +6616,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>centi</name>
-         <description>SI unit submultiple representing 10^-2</description>
+         <description>SI unit submultiple representing 10^-2.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6627,7 +6627,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>c</name>
-         <description>SI unit submultiple representing 10^-2</description>
+         <description>SI unit submultiple representing 10^-2.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6638,7 +6638,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>milli</name>
-         <description>SI unit submultiple representing 10^-3</description>
+         <description>SI unit submultiple representing 10^-3.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6649,7 +6649,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>m</name>
-         <description>SI unit submultiple representing 10^-3</description>
+         <description>SI unit submultiple representing 10^-3.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6660,7 +6660,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>micro</name>
-         <description>SI unit submultiple representing 10^-6</description>
+         <description>SI unit submultiple representing 10^-6.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6671,7 +6671,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>u</name>
-         <description>SI unit submultiple representing 10^-6</description>
+         <description>SI unit submultiple representing 10^-6.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6682,7 +6682,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>nano</name>
-         <description>SI unit submultiple representing 10^-9</description>
+         <description>SI unit submultiple representing 10^-9.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6693,7 +6693,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>n</name>
-         <description>SI unit submultiple representing 10^-9</description>
+         <description>SI unit submultiple representing 10^-9.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6704,7 +6704,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>pico</name>
-         <description>SI unit submultiple representing 10^-12</description>
+         <description>SI unit submultiple representing 10^-12.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6715,7 +6715,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>p</name>
-         <description>SI unit submultiple representing 10^-12</description>
+         <description>SI unit submultiple representing 10^-12.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6726,7 +6726,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>femto</name>
-         <description>SI unit submultiple representing 10^-15</description>
+         <description>SI unit submultiple representing 10^-15.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6737,7 +6737,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>f</name>
-         <description>SI unit submultiple representing 10^-15</description>
+         <description>SI unit submultiple representing 10^-15.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6748,7 +6748,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>atto</name>
-         <description>SI unit submultiple representing 10^-18</description>
+         <description>SI unit submultiple representing 10^-18.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6759,7 +6759,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>a</name>
-         <description>SI unit submultiple representing 10^-18</description>
+         <description>SI unit submultiple representing 10^-18.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6770,7 +6770,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>zepto</name>
-         <description>SI unit submultiple representing 10^-21</description>
+         <description>SI unit submultiple representing 10^-21.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6781,7 +6781,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>z</name>
-         <description>SI unit submultiple representing 10^-21</description>
+         <description>SI unit submultiple representing 10^-21.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>
@@ -6792,7 +6792,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>yocto</name>
-         <description>SI unit submultiple representing 10^-24</description>
+         <description>SI unit submultiple representing 10^-24.</description>
          <attribute>
             <name>SIUnitModifier</name>
          </attribute>
@@ -6803,7 +6803,7 @@ This project was supported by the by the National Institute of Mental Health of 
       </unitModifierDefinition>
       <unitModifierDefinition>
          <name>y</name>
-         <description>SI unit submultiple representing 10^-24</description>
+         <description>SI unit submultiple representing 10^-24.</description>
          <attribute>
             <name>SIUnitSymbolModifier</name>
          </attribute>


### PR DESCRIPTION
Added the `electricPotentialUnits` to both the base schema and the score.  The HED working group discussed and felt that this `unitClass` should be used rather than `amplitudeUnits`. 

Also the `conversionFactor` schema attribute was added to both the base schema and score.

