### PR TITLE
'Frequency' in base scheme vs. in SCORE schema

### DIFF
--- a/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.mediawiki
@@ -232,11 +232,11 @@ This project was supported by the by the National Institute of Mental Health of 
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Hypopnea-respiration <nowiki>[Add duration (range in seconds) and comments in free text]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-            *** Apnea-hypopnea-index-respiration <nowiki> {requireChild,suggestedTag=Finding-frequency} [Events/h.]</nowiki>
+            *** Apnea-hypopnea-index-respiration <nowiki> {requireChild} [Events/h. Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Periodic-respiration
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-            *** Tachypnea-respiration <nowiki> {requireChild,suggestedTag=Finding-frequency} [Cycles/min.]</nowiki>
+            *** Tachypnea-respiration <nowiki> {requireChild} [Cycles/min. Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-respiration-feature {requireChild}
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
@@ -244,19 +244,19 @@ This project was supported by the by the National Institute of Mental Health of 
         ** ECG-QT-period
             *** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
         ** ECG-feature
-            *** ECG-sinus-rhythm <nowiki>{suggestedTag=Finding-frequency}[Normal rhythm.]</nowiki>
+            *** ECG-sinus-rhythm <nowiki>[Normal rhythm. Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-arrhythmia
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-asystolia <nowiki>[Add duration (range in seconds) and comments in free text.]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-            *** ECG-bradycardia {suggestedTag=Finding-frequency}
+            *** ECG-bradycardia <nowiki>[Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** ECG-extrasystole
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-            *** ECG-ventricular-premature-depolarization {suggestedTag=Finding-frequency}
+            *** ECG-ventricular-premature-depolarization <nowiki>[Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-            *** ECG-tachycardia {suggestedTag=Finding-frequency}
+            *** ECG-tachycardia <nowiki>[Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency]</nowiki>
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
             *** Other-ECG-feature {requireChild}
                 **** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
@@ -274,7 +274,7 @@ This project was supported by the by the National Institute of Mental Health of 
             *** EMG-myoclonus
                 **** Negative-myoclonus
                     ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
-                **** EMG-myoclonus-rhythmic {suggestedTag=Finding-frequency}
+                **** EMG-myoclonus-rhythmic
                         ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>
                     **** EMG-myoclonus-arrhythmic
                         ***** <nowiki># {takesValue, valueClass=textClass}[Free text.]</nowiki>

--- a/library_schemas/score/prerelease/HED_score_1.0.0.xml
+++ b/library_schemas/score/prerelease/HED_score_1.0.0.xml
@@ -1860,13 +1860,9 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Apnea-hypopnea-index-respiration</name>
-                  <description>Events/h.</description>
+                  <description>Events/h. Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency</description>
                   <attribute>
                      <name>requireChild</name>
-                  </attribute>
-                  <attribute>
-                     <name>suggestedTag</name>
-                     <value>Finding-frequency</value>
                   </attribute>
                   <node>
                      <name>#</name>
@@ -1896,13 +1892,9 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>Tachypnea-respiration</name>
-                  <description>Cycles/min.</description>
+                  <description>Cycles/min. Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency</description>
                   <attribute>
                      <name>requireChild</name>
-                  </attribute>
-                  <attribute>
-                     <name>suggestedTag</name>
-                     <value>Finding-frequency</value>
                   </attribute>
                   <node>
                      <name>#</name>
@@ -1960,11 +1952,7 @@ This project was supported by the by the National Institute of Mental Health of 
                <name>ECG-feature</name>
                <node>
                   <name>ECG-sinus-rhythm</name>
-                  <description>Normal rhythm.</description>
-                  <attribute>
-                     <name>suggestedTag</name>
-                     <value>Finding-frequency</value>
-                  </attribute>
+                  <description>Normal rhythm. Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency</description>
                   <node>
                      <name>#</name>
                      <description>Free text.</description>
@@ -2008,10 +1996,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>ECG-bradycardia</name>
-                  <attribute>
-                     <name>suggestedTag</name>
-                     <value>Finding-frequency</value>
-                  </attribute>
+                  <description>Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency</description>
                   <node>
                      <name>#</name>
                      <description>Free text.</description>
@@ -2040,10 +2025,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>ECG-ventricular-premature-depolarization</name>
-                  <attribute>
-                     <name>suggestedTag</name>
-                     <value>Finding-frequency</value>
-                  </attribute>
+                  <description>Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency</description>
                   <node>
                      <name>#</name>
                      <description>Free text.</description>
@@ -2058,10 +2040,7 @@ This project was supported by the by the National Institute of Mental Health of 
                </node>
                <node>
                   <name>ECG-tachycardia</name>
-                  <attribute>
-                     <name>suggestedTag</name>
-                     <value>Finding-frequency</value>
-                  </attribute>
+                  <description>Frequency can be tagged with base schema /Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency</description>
                   <node>
                      <name>#</name>
                      <description>Free text.</description>
@@ -2179,10 +2158,6 @@ This project was supported by the by the National Institute of Mental Health of 
                   </node>
                   <node>
                      <name>EMG-myoclonus-rhythmic</name>
-                     <attribute>
-                        <name>suggestedTag</name>
-                        <value>Finding-frequency</value>
-                     </attribute>
                      <node>
                         <name>#</name>
                         <description>Free text.</description>


### PR DESCRIPTION
Changing cases where we need to use the general base scheme 'Frequency' term (/Property/Data-property/Data-value/Spatiotemporal-value/Rate-of-change/Frequency, defined as: Frequency is the number of occurrences of a repeating event per unit time.) to cases where we need to use SCORE 'Frequency' term (Finding-property/Other-finding-property/Finding-frequency, defined as: Value in Hz (number) typed in).